### PR TITLE
Fix main CI type-check for page assign

### DIFF
--- a/src/composables/use-browser-page-assign.ts
+++ b/src/composables/use-browser-page-assign.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue'
 import { toast } from 'vue-sonner'
+import useFleetSidebar, { chatTitleForId } from '@/composables/use-fleet-sidebar'
 import { isHomeChatSlug } from '@/constants/home-chat'
 import {
   assignExclusivePreferredSession,


### PR DESCRIPTION
## Summary
- Main CI failed on `vue-tsc --build` because `use-browser-page-assign.ts` used `useFleetSidebar` and `chatTitleForId` without importing them.
- Add the same explicit import sibling composables already use so type-check and Tauri `beforeBuildCommand` succeed.

## Test plan
- [x] `npm run ci` locally
- [x] `cargo test --no-default-features --manifest-path src-tauri/Cargo.toml`
- [ ] Confirm GitHub Actions CI and Tauri build jobs go green on this PR