### PR TITLE
fix: prevent stale context across chats

### DIFF
--- a/spec/src/composables/agent-harness/cache.test.ts
+++ b/spec/src/composables/agent-harness/cache.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  dropAgentHarness,
   getCachedAgentHarness,
   rekeyAgentHarness,
   resetAgentHarnessCacheForTests,
@@ -13,6 +14,7 @@ describe('rekeyAgentHarness', () => {
 
   it('moves the same harness instance and drops the old key', () => {
     const instance = {
+      markDisposed: vi.fn<() => void>(),
       dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     }
     setCachedAgentHarness('_home_', 'chat-1', instance)
@@ -21,5 +23,33 @@ describe('rekeyAgentHarness', () => {
 
     expect(getCachedAgentHarness('_home_', 'chat-1')).toBeUndefined()
     expect(getCachedAgentHarness('dest', 'chat-1')).toBe(instance)
+  })
+})
+
+describe('dropAgentHarness', () => {
+  beforeEach(() => {
+    resetAgentHarnessCacheForTests()
+  })
+
+  it('marks disposed synchronously before async dispose finishes', async () => {
+    let release: (() => void) | undefined
+    const disposePromise = new Promise<void>((resolve) => {
+      release = () => resolve()
+    })
+    const markDisposed = vi.fn<() => void>()
+    const dispose = vi.fn<() => Promise<void>>().mockReturnValue(disposePromise)
+    setCachedAgentHarness('proj', 'chat-1', { markDisposed, dispose })
+
+    dropAgentHarness('proj', 'chat-1')
+
+    expect(getCachedAgentHarness('proj', 'chat-1')).toBeUndefined()
+    expect(markDisposed).toHaveBeenCalledTimes(1)
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(markDisposed.mock.invocationCallOrder[0]).toBeLessThan(
+      dispose.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    )
+
+    release?.()
+    await disposePromise
   })
 })

--- a/spec/src/composables/agent-harness/events.test.ts
+++ b/spec/src/composables/agent-harness/events.test.ts
@@ -70,6 +70,10 @@ const buildState = (): AgentHarnessState =>
       refreshContextBudget: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     },
     compacting: ref(false),
+    disposed: ref(false),
+    chatStore: {
+      isSessionActive: vi.fn<() => boolean>().mockReturnValue(true),
+    },
   }) as unknown as AgentHarnessState
 
 const buildAttention = (): AttentionHelpers =>
@@ -412,5 +416,74 @@ describe('agent-harness events workspace-moved', () => {
       description: 'no graph',
     })
     expect(refreshSlug).not.toHaveBeenCalled()
+  })
+})
+
+describe('agent-harness events visible context gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const fireVisibleContextEvents = (state: AgentHarnessState): void => {
+    const { handleEvent } = createEvents(state, buildAttention(), deps)
+
+    handleEvent({
+      type: 'context-budget',
+      modelId: 'gpt-4o',
+      used: 999,
+      promptUsed: 999,
+      limit: 128_000,
+      reservedOutput: 8_192,
+      safetyBuffer: 2_000,
+      free: 0,
+      buckets: [],
+    })
+    handleEvent({
+      type: 'context-usage',
+      modelId: 'gpt-4o',
+      promptTokens: 50,
+      inputTokens: 50,
+      outputTokens: 5,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    })
+    handleEvent({
+      type: 'billable-usage',
+      record: billableRecord({ id: 'row-bg', source: 'main' }),
+    })
+    handleEvent({
+      type: 'compaction',
+      summary: 'recap',
+      focus: null,
+    })
+  }
+
+  it('does not let an inactive harness overwrite visible context', () => {
+    const state = buildState()
+    vi.mocked(state.chatStore.isSessionActive).mockReturnValue(false)
+
+    fireVisibleContextEvents(state)
+
+    expect(state.billableUsageRecords.value).toHaveLength(1)
+    expect(state.session.appendLocalCompaction).toHaveBeenCalledWith('recap', null)
+    expect(state.compacting.value).toBe(false)
+    expect(state.contextUsage.setBudget).not.toHaveBeenCalled()
+    expect(state.contextUsage.setLastStepUsage).not.toHaveBeenCalled()
+    expect(state.contextUsage.clearLastStepUsage).not.toHaveBeenCalled()
+    expect(state.contextBudgetSync.refreshContextBudget).not.toHaveBeenCalled()
+  })
+
+  it('does not let a disposed harness write visible context', () => {
+    const state = buildState()
+    state.disposed.value = true
+
+    fireVisibleContextEvents(state)
+
+    expect(state.billableUsageRecords.value).toHaveLength(1)
+    expect(state.session.appendLocalCompaction).toHaveBeenCalledWith('recap', null)
+    expect(state.contextUsage.setBudget).not.toHaveBeenCalled()
+    expect(state.contextUsage.setLastStepUsage).not.toHaveBeenCalled()
+    expect(state.contextUsage.clearLastStepUsage).not.toHaveBeenCalled()
+    expect(state.contextBudgetSync.refreshContextBudget).not.toHaveBeenCalled()
   })
 })

--- a/spec/src/composables/agent-harness/restore-usage.test.ts
+++ b/spec/src/composables/agent-harness/restore-usage.test.ts
@@ -42,6 +42,7 @@ const record = (
 const buildState = (overrides?: {
   status?: 'ready' | 'streaming'
   sessionActive?: boolean
+  disposed?: boolean
 }): AgentHarnessState => {
   const setLastStepUsage = vi.fn<(usage: unknown) => void>()
   return {
@@ -57,6 +58,7 @@ const buildState = (overrides?: {
       lastStepUsage: ref(null),
       setLastStepUsage,
     },
+    disposed: ref(overrides?.disposed ?? false),
     chatStore: {
       isSessionActive: () => overrides?.sessionActive ?? true,
     },
@@ -166,6 +168,24 @@ describe('restoreUsageLedger', () => {
     ])
 
     const state = buildState({ sessionActive: false })
+    const { restoreUsageLedger } = createRestoreUsage(state)
+    await restoreUsageLedger()
+
+    expect(state.turnUsageByTurnId.value['turn-a']?.inputTokens).toBe(100)
+    expect(state.contextUsage.setLastStepUsage).not.toHaveBeenCalled()
+  })
+
+  it('skips last-step when the harness is disposed', async () => {
+    readUsageLedger.mockResolvedValue([
+      record({
+        id: 'row-1',
+        turnId: 'turn-a',
+        source: 'main',
+        at: '2026-01-01T00:00:00.000Z',
+      }),
+    ])
+
+    const state = buildState({ disposed: true, sessionActive: true })
     const { restoreUsageLedger } = createRestoreUsage(state)
     await restoreUsageLedger()
 

--- a/spec/src/composables/agent-harness/session-ops.test.ts
+++ b/spec/src/composables/agent-harness/session-ops.test.ts
@@ -103,7 +103,11 @@ const buildState = (overrides?: {
     },
     status: ref(overrides?.status ?? 'ready'),
     compacting,
+    disposed: ref(false),
     contextUsage: { clearLastStepUsage: vi.fn<() => void>() },
+    chatStore: {
+      isSessionActive: () => true,
+    },
   } as unknown as AgentHarnessState
 }
 

--- a/spec/src/composables/agent-harness/session-ops.test.ts
+++ b/spec/src/composables/agent-harness/session-ops.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 import type { AgentHarnessState } from '@/composables/agent-harness/types'
+import type { ChatMetaRecord } from '@/services/vixl/vixl-tauri/types'
 import type { VixlSettings } from '@/types/vixl/vixl-settings'
 
 const compactSession = vi.hoisted(() =>
@@ -8,6 +9,7 @@ const compactSession = vi.hoisted(() =>
     summary: string
     checkpointLineId: string
     includeFromCreatedAt: string
+    usedFallback: boolean
   }>>(),
 )
 const toastError = vi.hoisted(() => vi.fn<(...args: unknown[]) => void>())
@@ -25,7 +27,7 @@ vi.mock('@/services/harness/write-handoff', () => ({
 }))
 
 vi.mock('@/services/vixl/vixl-tauri', () => ({
-  createChat: vi.fn<(...args: unknown[]) => Promise<{ id: string }>>(),
+  createChat: vi.fn<(...args: unknown[]) => Promise<ChatMetaRecord>>(),
 }))
 
 vi.mock('@/services/chat/pending-message', () => ({
@@ -56,6 +58,8 @@ vi.mock('vue-sonner', () => ({
 }))
 
 import createSessionOps from '@/composables/agent-harness/session-ops'
+import { createChat } from '@/services/vixl/vixl-tauri'
+import router from '@/router'
 
 const settings = (): VixlSettings => ({ version: 1 })
 
@@ -63,7 +67,23 @@ const compactResult = {
   summary: 'Short recap',
   checkpointLineId: 'cp-1',
   includeFromCreatedAt: '2026-01-01T00:00:00.000Z',
+  usedFallback: false,
 }
+
+const newChatMeta = (): ChatMetaRecord => ({
+  id: 'chat-2',
+  title: 'Handoff from Chat',
+  projectSlug: 'proj',
+  projectRoot: '/tmp/proj',
+  mode: 'agent',
+  model: 'local::qwen',
+  status: 'idle',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  forkedFrom: null,
+  pinned: false,
+  pinnedAt: null,
+})
 
 const buildState = (overrides?: {
   status?: 'ready' | 'streaming' | 'submitted'
@@ -247,6 +267,27 @@ describe('sessionOps compactChat', () => {
     expect(compactSession.mock.calls[0]?.[0]).not.toHaveProperty('transcript')
     expect(toastSuccess).toHaveBeenCalled()
   })
+
+  it('keeps a success toast with fallback copy when compaction used a deterministic summary', async () => {
+    compactSession.mockResolvedValue({
+      ...compactResult,
+      usedFallback: true,
+    })
+    const state = buildState()
+    const { compactChat } = createSessionOps(state, {
+      handleEvent: vi.fn<(...args: unknown[]) => void>(),
+      maybeDrainQueue: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    })
+
+    await compactChat()
+
+    expect(toastSuccess).toHaveBeenCalledWith(
+      'Context compacted',
+      expect.objectContaining({
+        description: 'A deterministic fallback summary was used.',
+      }),
+    )
+  })
 })
 
 describe('sessionOps createHandoff', () => {
@@ -322,6 +363,32 @@ describe('sessionOps createHandoff', () => {
     expect(compactSession.mock.calls[0]?.[0]).not.toHaveProperty('transcript')
     expect(writeHandoff).toHaveBeenCalledWith(
       expect.objectContaining({ summary: compactResult.summary }),
+    )
+  })
+
+  it('reflects a deterministic fallback summary in the handoff success toast', async () => {
+    compactSession.mockResolvedValue({
+      ...compactResult,
+      usedFallback: true,
+    })
+    vi.mocked(createChat).mockResolvedValue(newChatMeta())
+    vi.mocked(router.push).mockResolvedValue(undefined as never)
+    const state = buildState()
+    const { createHandoff } = createSessionOps(state, {
+      handleEvent: vi.fn<(...args: unknown[]) => void>(),
+      maybeDrainQueue: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    })
+
+    await createHandoff()
+
+    expect(writeHandoff).toHaveBeenCalledWith(
+      expect.objectContaining({ summary: compactResult.summary }),
+    )
+    expect(toastSuccess).toHaveBeenCalledWith(
+      'Handoff created',
+      expect.objectContaining({
+        description: 'New chat opened with a deterministic fallback summary.',
+      }),
     )
   })
 })

--- a/spec/src/composables/chat-store/session.test.ts
+++ b/spec/src/composables/chat-store/session.test.ts
@@ -294,4 +294,55 @@ describe('chat session registry isolation', () => {
     releaseMeta?.(metaFor('chat-a'))
     await hydrating
   })
+
+  it('does not reset bound usage after selectChat before hydrate when loading is false', async () => {
+    const { default: useChatStore, resetChatSessionsForTests } = await import(
+      '@/composables/use-chat-store'
+    )
+    const { default: useContextUsage } = await import(
+      '@/composables/use-context-usage'
+    )
+    const { default: useChatContextBudgetSync } = await import(
+      '@/composables/use-chat-context-budget-sync'
+    )
+    resetChatSessionsForTests()
+    const store = useChatStore()
+    const contextUsage = useContextUsage()
+    const sync = useChatContextBudgetSync()
+
+    store.selectChat('proj', 'chat-a')
+    expect(store.chatId.value).toBe('chat-a')
+    expect(store.meta.value).toBeNull()
+    expect(store.loading.value).toBe(false)
+
+    contextUsage.setBudget({
+      modelId: 'test/model',
+      limit: 262_000,
+      promptUsed: 5_000,
+      reservedOutput: 33_000,
+      safetyBuffer: 2_000,
+      free: 222_000,
+      used: 5_000,
+      buckets: [{ id: 'messages', label: 'Conversation', tokens: 5_000 }],
+    })
+    contextUsage.setLastStepUsage({
+      promptTokens: 51_000,
+      inputTokens: 51_000,
+      outputTokens: 1_200,
+      cacheReadTokens: 47_000,
+      cacheWriteTokens: 0,
+    })
+    expect(contextUsage.promptUsed.value).toBe(51_000)
+
+    await sync.refreshContextBudget()
+    await nextTick()
+    await new Promise<void>((resolve) => {
+      window.setTimeout(resolve, 0)
+    })
+
+    expect(store.meta.value).toBeNull()
+    expect(store.loading.value).toBe(false)
+    expect(contextUsage.lastStepUsage.value?.inputTokens).toBe(51_000)
+    expect(contextUsage.promptUsed.value).toBe(51_000)
+  })
 })

--- a/spec/src/composables/chat-store/session.test.ts
+++ b/spec/src/composables/chat-store/session.test.ts
@@ -145,4 +145,92 @@ describe('chat session registry isolation', () => {
       ),
     ).toBe(true)
   })
+
+  it('clears context usage when the active chat becomes null', async () => {
+    const { default: useChatStore, resetChatSessionsForTests } = await import(
+      '@/composables/use-chat-store'
+    )
+    const { default: useContextUsage } = await import(
+      '@/composables/use-context-usage'
+    )
+    resetChatSessionsForTests()
+    const store = useChatStore()
+    const contextUsage = useContextUsage()
+
+    await store.loadChat('proj', 'chat-a')
+    contextUsage.setBudget({
+      modelId: 'test/model',
+      limit: 262_000,
+      promptUsed: 5_000,
+      reservedOutput: 33_000,
+      safetyBuffer: 2_000,
+      free: 222_000,
+      used: 5_000,
+      buckets: [{ id: 'messages', label: 'Conversation', tokens: 5_000 }],
+    })
+    contextUsage.setLastStepUsage({
+      promptTokens: 51_000,
+      inputTokens: 51_000,
+      outputTokens: 1_200,
+      cacheReadTokens: 47_000,
+      cacheWriteTokens: 0,
+    })
+    expect(contextUsage.promptUsed.value).toBe(51_000)
+
+    store.clearChatState()
+
+    expect(store.meta.value).toBeNull()
+    expect(contextUsage.lastStepUsage.value).toBeNull()
+    expect(contextUsage.promptUsed.value).toBe(0)
+  })
+
+  it('does not inherit context fill after delete then create with the same project and model', async () => {
+    const vixl = await import('@/services/vixl/vixl-tauri')
+    const { default: useChatStore, resetChatSessionsForTests } = await import(
+      '@/composables/use-chat-store'
+    )
+    const { default: useContextUsage } = await import(
+      '@/composables/use-context-usage'
+    )
+    resetChatSessionsForTests()
+    const store = useChatStore()
+    const contextUsage = useContextUsage()
+
+    await store.loadChat('proj', 'chat-a')
+    contextUsage.setBudget({
+      modelId: 'test/model',
+      limit: 262_000,
+      promptUsed: 5_000,
+      reservedOutput: 33_000,
+      safetyBuffer: 2_000,
+      free: 222_000,
+      used: 5_000,
+      buckets: [{ id: 'messages', label: 'Conversation', tokens: 5_000 }],
+    })
+    contextUsage.setLastStepUsage({
+      promptTokens: 51_000,
+      inputTokens: 51_000,
+      outputTokens: 1_200,
+      cacheReadTokens: 47_000,
+      cacheWriteTokens: 0,
+    })
+    expect(contextUsage.promptUsed.value).toBe(51_000)
+
+    store.dropSession('proj', 'chat-a')
+    expect(store.meta.value).toBeNull()
+    expect(contextUsage.lastStepUsage.value).toBeNull()
+    expect(contextUsage.promptUsed.value).toBe(0)
+
+    vi.mocked(vixl.createChat).mockResolvedValueOnce(metaFor('chat-new'))
+    await store.createNewChat({
+      projectSlug: 'proj',
+      projectRoot: '/proj',
+      mode: 'agent',
+      model: 'test/model',
+    })
+
+    expect(store.meta.value?.id).toBe('chat-new')
+    expect(contextUsage.lastStepUsage.value).toBeNull()
+    expect(contextUsage.promptUsed.value).toBe(0)
+  })
 })

--- a/spec/src/composables/chat-store/session.test.ts
+++ b/spec/src/composables/chat-store/session.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import { mockVixlTauri } from '../../test-utils/mocks/vixl-tauri'
 
 const { metaFor } = vi.hoisted(() => {
@@ -232,5 +233,65 @@ describe('chat session registry isolation', () => {
     expect(store.meta.value?.id).toBe('chat-new')
     expect(contextUsage.lastStepUsage.value).toBeNull()
     expect(contextUsage.promptUsed.value).toBe(0)
+  })
+
+  it('does not reset bound usage while cold hydrate is loading without meta', async () => {
+    const vixl = await import('@/services/vixl/vixl-tauri')
+    const { default: useChatStore, resetChatSessionsForTests } = await import(
+      '@/composables/use-chat-store'
+    )
+    const { default: useContextUsage } = await import(
+      '@/composables/use-context-usage'
+    )
+    const { default: useChatContextBudgetSync } = await import(
+      '@/composables/use-chat-context-budget-sync'
+    )
+    resetChatSessionsForTests()
+    const store = useChatStore()
+    const contextUsage = useContextUsage()
+    useChatContextBudgetSync()
+
+    store.selectChat('proj', 'chat-a')
+    contextUsage.setBudget({
+      modelId: 'test/model',
+      limit: 262_000,
+      promptUsed: 5_000,
+      reservedOutput: 33_000,
+      safetyBuffer: 2_000,
+      free: 222_000,
+      used: 5_000,
+      buckets: [{ id: 'messages', label: 'Conversation', tokens: 5_000 }],
+    })
+    contextUsage.setLastStepUsage({
+      promptTokens: 51_000,
+      inputTokens: 51_000,
+      outputTokens: 1_200,
+      cacheReadTokens: 47_000,
+      cacheWriteTokens: 0,
+    })
+    expect(contextUsage.promptUsed.value).toBe(51_000)
+
+    let releaseMeta: ((value: ReturnType<typeof metaFor>) => void) | undefined
+    vi.mocked(vixl.readChatMeta).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseMeta = resolve
+        }),
+    )
+
+    const hydrating = store.ensureChatHydrated('proj', 'chat-a')
+    expect(store.loading.value).toBe(true)
+    expect(store.meta.value).toBeNull()
+
+    await nextTick()
+    await new Promise<void>((resolve) => {
+      window.setTimeout(resolve, 0)
+    })
+
+    expect(contextUsage.lastStepUsage.value?.inputTokens).toBe(51_000)
+    expect(contextUsage.promptUsed.value).toBe(51_000)
+
+    releaseMeta?.(metaFor('chat-a'))
+    await hydrating
   })
 })

--- a/spec/src/composables/use-chat-context-budget-sync.test.ts
+++ b/spec/src/composables/use-chat-context-budget-sync.test.ts
@@ -10,6 +10,10 @@ const refreshFns = vi.hoisted(() => ({
   current: [] as Array<ReturnType<typeof vi.fn>>,
 }))
 
+const bindChatFns = vi.hoisted(() => ({
+  current: [] as Array<ReturnType<typeof vi.fn>>,
+}))
+
 const loading = ref(false)
 const timeline = ref<ChatTimelineItem[]>([])
 const messages = ref<UIMessage[]>([])
@@ -30,8 +34,10 @@ vi.mock('@/composables/use-chat-store', () => ({
 vi.mock('@/composables/use-context-usage', () => ({
   default: () => {
     const refresh = vi.fn<() => Promise<void>>(async () => undefined)
+    const bindChat = vi.fn<(chatId: string | null) => void>()
     refreshFns.current.push(refresh)
-    return { refresh }
+    bindChatFns.current.push(bindChat)
+    return { refresh, bindChat }
   },
 }))
 
@@ -94,6 +100,7 @@ describe('useChatContextBudgetSync', () => {
   beforeEach(() => {
     vi.resetModules()
     refreshFns.current = []
+    bindChatFns.current = []
     loading.value = false
     timeline.value = []
     messages.value = []
@@ -110,12 +117,36 @@ describe('useChatContextBudgetSync', () => {
     )
     const sync = useChatContextBudgetSync()
     const refresh = refreshFns.current.at(-1)
+    const bindChat = bindChatFns.current.at(-1)
     expect(refresh).toBeDefined()
+    expect(bindChat).toBeDefined()
+    bindChat?.mockClear()
 
     await sync.refreshContextBudget()
     await flushDeferredRefresh()
 
     expect(refresh).not.toHaveBeenCalled()
+    expect(bindChat).toHaveBeenCalledWith('chat-1')
+  })
+
+  it('binds null and skips refresh when there is no active chat', async () => {
+    meta.value = null
+    const { default: useChatContextBudgetSync } = await import(
+      '@/composables/use-chat-context-budget-sync'
+    )
+    const sync = useChatContextBudgetSync()
+    const refresh = refreshFns.current.at(-1)
+    const bindChat = bindChatFns.current.at(-1)
+    expect(refresh).toBeDefined()
+    expect(bindChat).toBeDefined()
+    refresh?.mockClear()
+    bindChat?.mockClear()
+
+    await sync.refreshContextBudget()
+    await flushDeferredRefresh()
+
+    expect(refresh).not.toHaveBeenCalled()
+    expect(bindChat).toHaveBeenCalledWith(null)
   })
 
   it('applies refresh when loading is false and model and project root exist', async () => {

--- a/spec/src/composables/use-chat-context-budget-sync.test.ts
+++ b/spec/src/composables/use-chat-context-budget-sync.test.ts
@@ -129,6 +129,28 @@ describe('useChatContextBudgetSync', () => {
     expect(bindChat).toHaveBeenCalledWith('chat-1')
   })
 
+  it('does not unbind during cold hydration while loading and meta is still null', async () => {
+    loading.value = true
+    meta.value = null
+    const { default: useChatContextBudgetSync } = await import(
+      '@/composables/use-chat-context-budget-sync'
+    )
+    const sync = useChatContextBudgetSync()
+    const refresh = refreshFns.current.at(-1)
+    const bindChat = bindChatFns.current.at(-1)
+    expect(refresh).toBeDefined()
+    expect(bindChat).toBeDefined()
+    refresh?.mockClear()
+    bindChat?.mockClear()
+
+    await sync.refreshContextBudget()
+    await flushDeferredRefresh()
+
+    expect(refresh).not.toHaveBeenCalled()
+    expect(bindChat).not.toHaveBeenCalled()
+    expect(bindChat).not.toHaveBeenCalledWith(null)
+  })
+
   it('binds null and skips refresh when there is no active chat', async () => {
     meta.value = null
     const { default: useChatContextBudgetSync } = await import(

--- a/spec/src/composables/use-chat-context-budget-sync.test.ts
+++ b/spec/src/composables/use-chat-context-budget-sync.test.ts
@@ -18,6 +18,7 @@ const loading = ref(false)
 const timeline = ref<ChatTimelineItem[]>([])
 const messages = ref<UIMessage[]>([])
 const meta = ref<ChatMeta | null>(null)
+const chatId = ref<string | null>(null)
 const activeProject = ref<FleetProject | null>(null)
 const serverStates = ref<Record<string, { status: string; tools: unknown[] }>>({})
 const effectiveSettings = ref(defaultVixlSettings())
@@ -28,6 +29,7 @@ vi.mock('@/composables/use-chat-store', () => ({
     timeline,
     messages,
     meta,
+    chatId,
   }),
 }))
 
@@ -105,6 +107,7 @@ describe('useChatContextBudgetSync', () => {
     timeline.value = []
     messages.value = []
     meta.value = sampleMeta()
+    chatId.value = 'chat-1'
     activeProject.value = sampleProject()
     serverStates.value = {}
     effectiveSettings.value = defaultVixlSettings()
@@ -132,6 +135,30 @@ describe('useChatContextBudgetSync', () => {
   it('does not unbind during cold hydration while loading and meta is still null', async () => {
     loading.value = true
     meta.value = null
+    chatId.value = 'chat-1'
+    const { default: useChatContextBudgetSync } = await import(
+      '@/composables/use-chat-context-budget-sync'
+    )
+    const sync = useChatContextBudgetSync()
+    const refresh = refreshFns.current.at(-1)
+    const bindChat = bindChatFns.current.at(-1)
+    expect(refresh).toBeDefined()
+    expect(bindChat).toBeDefined()
+    refresh?.mockClear()
+    bindChat?.mockClear()
+
+    await sync.refreshContextBudget()
+    await flushDeferredRefresh()
+
+    expect(refresh).not.toHaveBeenCalled()
+    expect(bindChat).not.toHaveBeenCalledWith(null)
+    expect(bindChat).toHaveBeenCalledWith('chat-1')
+  })
+
+  it('does not unbind after selectChat before hydrate when loading is still false', async () => {
+    loading.value = false
+    meta.value = null
+    chatId.value = 'chat-selected'
     const { default: useChatContextBudgetSync } = await import(
       '@/composables/use-chat-context-budget-sync'
     )
@@ -153,6 +180,7 @@ describe('useChatContextBudgetSync', () => {
 
   it('binds null and skips refresh when there is no active chat', async () => {
     meta.value = null
+    chatId.value = null
     const { default: useChatContextBudgetSync } = await import(
       '@/composables/use-chat-context-budget-sync'
     )

--- a/spec/src/composables/use-context-usage.test.ts
+++ b/spec/src/composables/use-context-usage.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ContextBudget } from '@/types/harness/context-budget'
+import type { RefreshContextUsageInput } from '@/composables/use-context-usage'
+
+const countContextBudget = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => Promise<ContextBudget>>(),
+)
+
+vi.mock('@/services/context/count-context-budget', () => ({
+  default: (...args: unknown[]) => countContextBudget(...args),
+}))
 
 const sampleBudget = (promptUsed: number): ContextBudget => ({
   modelId: 'test-model',
@@ -18,9 +27,30 @@ const sampleBudget = (promptUsed: number): ContextBudget => ({
   ],
 })
 
+const filledLastStep = {
+  promptTokens: 51_000,
+  inputTokens: 51_000,
+  outputTokens: 1_200,
+  cacheReadTokens: 47_000,
+  cacheWriteTokens: 0,
+}
+
+const refreshInput = (
+  chatId: string | undefined,
+): RefreshContextUsageInput => ({
+  modelId: 'test-model',
+  mode: 'agent',
+  projectName: 'Demo',
+  projectRoot: '/tmp/demo',
+  messages: [],
+  chatId,
+})
+
 describe('useContextUsage', () => {
   beforeEach(() => {
     vi.resetModules()
+    countContextBudget.mockReset()
+    countContextBudget.mockResolvedValue(sampleBudget(8_000))
   })
 
   it('keeps ring fill on the budget estimate after last-step usage', async () => {
@@ -89,5 +119,84 @@ describe('useContextUsage', () => {
     expect(contextUsage.promptUsed.value).toBe(170_000)
     expect(contextUsage.lastStepUsage.value).toBeNull()
     expect(contextUsage.hasLastStepUsage.value).toBe(false)
+  })
+
+  it('clears last-step usage and visible fill when the bound chat becomes null', async () => {
+    const { default: useContextUsage } = await import(
+      '@/composables/use-context-usage'
+    )
+    const contextUsage = useContextUsage()
+
+    contextUsage.bindChat('chat-a')
+    contextUsage.setBudget(sampleBudget(5_000))
+    contextUsage.setLastStepUsage(filledLastStep)
+    expect(contextUsage.promptUsed.value).toBe(51_000)
+
+    contextUsage.bindChat(null)
+
+    expect(contextUsage.lastStepUsage.value).toBeNull()
+    expect(contextUsage.hasLastStepUsage.value).toBe(false)
+    expect(contextUsage.promptUsed.value).toBe(0)
+    expect(contextUsage.estimatedPromptUsed.value).toBe(0)
+    expect(contextUsage.visibleBuckets.value).toEqual([])
+  })
+
+  it('does not floor a new chat to the previous chat last-step usage', async () => {
+    countContextBudget.mockResolvedValue(sampleBudget(8_000))
+    const { default: useContextUsage } = await import(
+      '@/composables/use-context-usage'
+    )
+    const contextUsage = useContextUsage()
+
+    contextUsage.bindChat('chat-old')
+    contextUsage.setBudget(sampleBudget(5_000))
+    contextUsage.setLastStepUsage(filledLastStep)
+    expect(contextUsage.promptUsed.value).toBe(51_000)
+
+    await contextUsage.refresh(refreshInput('chat-new'))
+
+    expect(contextUsage.lastStepUsage.value).toBeNull()
+    expect(contextUsage.promptUsed.value).toBe(8_000)
+  })
+
+  it('clears fill when refresh has no chatId after a bound chat', async () => {
+    countContextBudget.mockResolvedValue(sampleBudget(8_000))
+    const { default: useContextUsage } = await import(
+      '@/composables/use-context-usage'
+    )
+    const contextUsage = useContextUsage()
+
+    contextUsage.bindChat('chat-old')
+    contextUsage.setBudget(sampleBudget(5_000))
+    contextUsage.setLastStepUsage(filledLastStep)
+
+    await contextUsage.refresh(refreshInput(undefined))
+
+    expect(contextUsage.lastStepUsage.value).toBeNull()
+    expect(contextUsage.promptUsed.value).toBe(8_000)
+  })
+
+  it('discards an in-flight refresh after bindChat to another chat', async () => {
+    let resolveBudget: ((budget: ContextBudget) => void) | undefined
+    countContextBudget.mockImplementation(
+      () =>
+        new Promise<ContextBudget>((resolve) => {
+          resolveBudget = resolve
+        }),
+    )
+    const { default: useContextUsage } = await import(
+      '@/composables/use-context-usage'
+    )
+    const contextUsage = useContextUsage()
+
+    const pendingRefresh = contextUsage.refresh(refreshInput('chat-a'))
+    contextUsage.bindChat('chat-b')
+    expect(contextUsage.promptUsed.value).toBe(0)
+
+    resolveBudget?.(sampleBudget(99_000))
+    await pendingRefresh
+
+    expect(contextUsage.promptUsed.value).toBe(0)
+    expect(contextUsage.lastStepUsage.value).toBeNull()
   })
 })

--- a/spec/src/services/harness/compact/bound-rewritten-messages.test.ts
+++ b/spec/src/services/harness/compact/bound-rewritten-messages.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import type { ModelMessage } from 'ai'
+import boundRewrittenMessages from '@/services/harness/compact/bound-rewritten-messages'
+import { compactBudgets, estimatePromptTokens } from '@/services/harness/compact'
+
+const checkpoint = (summary: string): ModelMessage => ({
+  role: 'user',
+  content: `${compactBudgets.CHECKPOINT_PREFIX}\n${summary}`,
+})
+
+const toolCallIds = (messages: ModelMessage[]): string[] => {
+  const ids: string[] = []
+  for (const message of messages) {
+    if (message.role !== 'assistant' || !Array.isArray(message.content)) {
+      continue
+    }
+    for (const part of message.content) {
+      if (part.type === 'tool-call') {
+        ids.push(part.toolCallId)
+      }
+    }
+  }
+  return ids.sort()
+}
+
+const toolResultIds = (messages: ModelMessage[]): string[] => {
+  const ids: string[] = []
+  for (const message of messages) {
+    if (message.role !== 'tool' || !Array.isArray(message.content)) {
+      continue
+    }
+    for (const part of message.content) {
+      if (part.type === 'tool-result') {
+        ids.push(part.toolCallId)
+      }
+    }
+  }
+  return ids.sort()
+}
+
+const expectPairedTools = (messages: ModelMessage[]): void => {
+  expect(toolCallIds(messages)).toEqual(toolResultIds(messages))
+  for (const message of messages) {
+    if (message.role === 'tool') {
+      expect(Array.isArray(message.content)).toBe(true)
+    }
+  }
+}
+
+describe('boundRewrittenMessages', () => {
+  it('truncates an oversized first user message to fit high water', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'x'.repeat(80_000) },
+      checkpoint('short recap'),
+    ]
+    const system = 'sys'
+    const highWater = 2_000
+
+    const bounded = boundRewrittenMessages(messages, system, highWater)
+
+    expect(estimatePromptTokens(system, bounded)).toBeLessThanOrEqual(highWater)
+    expect(JSON.stringify(bounded[0]).length).toBeLessThan(
+      JSON.stringify(messages[0]).length,
+    )
+    expectPairedTools(bounded)
+  })
+
+  it('truncates a huge tool result while keeping the matching tool-call pair', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug.' },
+      checkpoint('Auth recap'),
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            input: { path: 'login.ts' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            output: { type: 'text', value: 'y'.repeat(80_000) },
+          },
+        ],
+      },
+    ]
+    const system = 'sys'
+    const highWater = 3_000
+
+    const bounded = boundRewrittenMessages(messages, system, highWater)
+
+    expect(estimatePromptTokens(system, bounded)).toBeLessThanOrEqual(highWater)
+    expect(JSON.stringify(bounded)).not.toContain('y'.repeat(80_000))
+    expectPairedTools(bounded)
+    const tool = bounded.find((message) => message.role === 'tool')
+    expect(tool?.role).toBe('tool')
+  })
+
+  it('drops an orphaned tool result instead of turning it into a user message', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug.' },
+      checkpoint('Auth recap'),
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-orphan',
+            toolName: 'read_file',
+            output: { type: 'text', value: 'y'.repeat(80_000) },
+          },
+        ],
+      },
+    ]
+    const system = 'sys'
+    const highWater = 3_000
+
+    const bounded = boundRewrittenMessages(messages, system, highWater)
+
+    expect(estimatePromptTokens(system, bounded)).toBeLessThanOrEqual(highWater)
+    expect(bounded.some((message) => message.role === 'tool')).toBe(false)
+    expect(JSON.stringify(bounded)).not.toContain('tool-result')
+    expectPairedTools(bounded)
+  })
+
+  it('drops unmatched assistant tool-calls when the tool result is removed', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'x'.repeat(20_000) },
+      checkpoint('recap'),
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-2',
+            toolName: 'read_file',
+            input: { path: 'a.ts' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-2',
+            toolName: 'read_file',
+            output: { type: 'text', value: 'z'.repeat(20_000) },
+          },
+        ],
+      },
+    ]
+    const system = 'sys'
+    const highWater = 800
+
+    const bounded = boundRewrittenMessages(messages, system, highWater)
+
+    expect(estimatePromptTokens(system, bounded)).toBeLessThanOrEqual(highWater)
+    expectPairedTools(bounded)
+  })
+})

--- a/spec/src/services/harness/compact/build-fallback-checkpoint.test.ts
+++ b/spec/src/services/harness/compact/build-fallback-checkpoint.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { ModelMessage } from 'ai'
+import buildFallbackCheckpoint from '@/services/harness/compact/build-fallback-checkpoint'
+
+describe('buildFallbackCheckpoint', () => {
+  it('includes counts and snippets from the first user and latest message', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug in login.' },
+      { role: 'assistant', content: 'Inspecting token refresh.' },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            output: { type: 'text', value: 'expired token handler' },
+          },
+        ],
+      },
+    ]
+
+    const summary = buildFallbackCheckpoint(messages)
+
+    expect(summary).toContain('Deterministic compaction fallback')
+    expect(summary).toContain('Message count: 3')
+    expect(summary).toContain('user=1')
+    expect(summary).toContain('Find the auth bug in login.')
+    expect(summary).toContain('expired token handler')
+  })
+
+  it('clips an oversized first user snippet', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'z'.repeat(10_000) },
+    ]
+
+    const summary = buildFallbackCheckpoint(messages)
+
+    expect(summary.length).toBeLessThan(10_000)
+    expect(summary).toContain('[truncated]')
+  })
+})

--- a/spec/src/services/harness/compact/compact-session.test.ts
+++ b/spec/src/services/harness/compact/compact-session.test.ts
@@ -1,14 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ModelMessage, UIMessage } from 'ai'
+import type { HarnessEvent } from '@/types/harness/harness-event'
 import type { VixlSettings } from '@/types/vixl/vixl-settings'
 import { mockVixlTauri } from '../../../test-utils/mocks/vixl-tauri'
 
 const generateCheckpoint = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<{
     summary: string
-    usage: undefined
-    providerMetadata: undefined
-    responseId: undefined
+    usage: undefined | { inputTokens: number; outputTokens: number }
+    providerMetadata: undefined | Record<string, unknown>
+    responseId: undefined | string
     modelRef: { providerId: string; modelId: string }
   }>>(),
 )
@@ -19,6 +20,10 @@ const persistCompactionCheckpoint = vi.hoisted(() =>
     checkpointLineId: string
   }>>(),
 )
+const captureBillableUsage = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => Promise<void>>(),
+)
+const toastError = vi.hoisted(() => vi.fn<(...args: unknown[]) => void>())
 const createModel = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<unknown>>(),
 )
@@ -41,6 +46,16 @@ vi.mock('@/services/providers/create-model', () => ({
   default: (...args: unknown[]) => createModel(...args),
 }))
 
+vi.mock('@/services/billing/capture-billable-usage', () => ({
+  default: (...args: unknown[]) => captureBillableUsage(...args),
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}))
+
 vi.mock('@/services/harness/resolve-model-vision', () => ({
   default: (...args: unknown[]) => resolveModelVision(...args),
 }))
@@ -51,13 +66,27 @@ vi.mock('@/services/vixl/vixl-tauri', () =>
   }),
 )
 
-import { compactBudgets } from '@/services/harness/compact'
+import { compactBudgets, stillExceedsMessage } from '@/services/harness/compact'
 import compactSession from '@/services/harness/compact-session'
+
+const hugeContent = 'x'.repeat(800_000)
 
 const settings = (): VixlSettings =>
   ({
     version: 1,
     'models.default': 'ollama::qwen',
+  }) as VixlSettings
+
+const tinyWindowSettings = (): VixlSettings =>
+  ({
+    version: 1,
+    'models.default': 'local::qwen',
+    'providers.custom.local': {
+      type: 'openai-compatible',
+      name: 'Local',
+      baseURL: 'http://127.0.0.1:11434/v1',
+      models: [{ id: 'qwen', contextWindow: 80, maxOutputTokens: 40 }],
+    },
   }) as VixlSettings
 
 const userMessage = (id: string, text: string, createdAt?: string): UIMessage => ({
@@ -103,6 +132,8 @@ describe('compactSession', () => {
       includeFromCreatedAt: '2026-01-01T00:00:00.000Z',
       checkpointLineId: 'cp-1',
     })
+    captureBillableUsage.mockResolvedValue(undefined)
+    toastError.mockReset()
   })
 
   it('throws before generating a checkpoint when there is nothing to compact', async () => {
@@ -191,5 +222,155 @@ describe('compactSession', () => {
     const serialized = JSON.stringify(call.messages)
     expect(serialized).toContain('new work')
     expect(serialized).not.toContain('stale turn')
+  })
+
+  it('returns usedFallback false and bills when a paid checkpoint succeeds', async () => {
+    generateCheckpoint.mockResolvedValue({
+      summary: 'recap',
+      usage: { inputTokens: 2, outputTokens: 1 },
+      providerMetadata: undefined,
+      responseId: 'r1',
+      modelRef: { providerId: 'ollama', modelId: 'qwen' },
+    })
+    const onEvent = vi.fn<(event: HarnessEvent) => void>()
+    const messages = [
+      userMessage('u1', 'check the file'),
+      assistantMessage('a1', 'done'),
+    ]
+
+    const result = await compactSession(compactInput({ messages, onEvent }))
+
+    expect(result.usedFallback).toBe(false)
+    expect(persistCompactionCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({ summary: 'recap' }),
+    )
+    expect(captureBillableUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'compaction',
+        providerId: 'ollama',
+        modelId: 'qwen',
+        responseId: 'r1',
+        usage: { inputTokens: 2, outputTokens: 1 },
+      }),
+    )
+  })
+
+  it('keeps the persisted checkpoint when recording usage fails', async () => {
+    captureBillableUsage.mockRejectedValue(new Error('billing network failed'))
+    const onEvent = vi.fn<(event: HarnessEvent) => void>()
+    const messages = [
+      userMessage('u1', 'check the file'),
+      assistantMessage('a1', 'done'),
+    ]
+
+    const result = await compactSession(compactInput({ messages, onEvent }))
+
+    expect(result.usedFallback).toBe(false)
+    expect(result.checkpointLineId).toBe('cp-1')
+    expect(persistCompactionCheckpoint).toHaveBeenCalledTimes(1)
+    expect(toastError).toHaveBeenCalledWith(
+      'Failed to record compaction usage',
+      expect.objectContaining({ description: 'billing network failed' }),
+    )
+  })
+
+  it('persists a deterministic fallback summary when checkpoint generation fails', async () => {
+    generateCheckpoint.mockRejectedValue(new Error('prompt is too long'))
+    const messages = [
+      userMessage('u1', 'check the file'),
+      assistantMessage('a1', 'working'),
+    ]
+
+    const result = await compactSession(
+      compactInput({ messages, onEvent: vi.fn<(event: HarnessEvent) => void>() }),
+    )
+
+    expect(result.usedFallback).toBe(true)
+    expect(generateCheckpoint).toHaveBeenCalledTimes(1)
+    expect(captureBillableUsage).not.toHaveBeenCalled()
+    expect(persistCompactionCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.stringContaining('Deterministic compaction fallback'),
+      }),
+    )
+  })
+
+  it('skips generation and persists fallback when the prompt is already over the hard window', async () => {
+    const messages = [userMessage('u1', hugeContent)]
+
+    const result = await compactSession(
+      compactInput({ messages, onEvent: vi.fn<(event: HarnessEvent) => void>() }),
+    )
+
+    expect(generateCheckpoint).not.toHaveBeenCalled()
+    expect(captureBillableUsage).not.toHaveBeenCalled()
+    expect(result.usedFallback).toBe(true)
+    expect(persistCompactionCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.stringContaining('Deterministic compaction fallback'),
+      }),
+    )
+  })
+
+  it('bills a paid checkpoint when the persisted summary is the overflow fallback', async () => {
+    generateCheckpoint.mockResolvedValue({
+      summary: 'M'.repeat(800_000),
+      usage: { inputTokens: 40, outputTokens: 20 },
+      providerMetadata: { paid: true },
+      responseId: 'r-paid',
+      modelRef: { providerId: 'ollama', modelId: 'qwen' },
+    })
+    const onEvent = vi.fn<(event: HarnessEvent) => void>()
+    const messages = [
+      userMessage('u1', 'Find the auth bug.'),
+      assistantMessage('a1', 'Inspecting token refresh.'),
+    ]
+
+    const result = await compactSession(compactInput({ messages, onEvent }))
+
+    expect(result.usedFallback).toBe(true)
+    expect(persistCompactionCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.stringContaining('Deterministic compaction fallback'),
+      }),
+    )
+    expect(captureBillableUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'compaction',
+        providerId: 'ollama',
+        modelId: 'qwen',
+        responseId: 'r-paid',
+        usage: { inputTokens: 40, outputTokens: 20 },
+      }),
+    )
+  })
+
+  it('rethrows abort and persists nothing', async () => {
+    const controller = new AbortController()
+    generateCheckpoint.mockImplementation(async () => {
+      controller.abort()
+      throw new Error('aborted')
+    })
+    const messages = [
+      userMessage('u1', 'check the file'),
+      assistantMessage('a1', 'working'),
+    ]
+
+    await expect(
+      compactSession(compactInput({ messages, signal: controller.signal })),
+    ).rejects.toThrow('aborted')
+    expect(persistCompactionCheckpoint).not.toHaveBeenCalled()
+    expect(captureBillableUsage).not.toHaveBeenCalled()
+  })
+
+  it('throws the shared still-exceeds message when bounding cannot fit under high water', async () => {
+    const messages = [userMessage('u1', hugeContent)]
+
+    await expect(
+      compactSession(
+        compactInput({ messages, settings: tinyWindowSettings() }),
+      ),
+    ).rejects.toThrow(stillExceedsMessage('none'))
+    expect(persistCompactionCheckpoint).not.toHaveBeenCalled()
   })
 })

--- a/spec/src/services/harness/compact/repair-tool-pairing.test.ts
+++ b/spec/src/services/harness/compact/repair-tool-pairing.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import type { ModelMessage } from 'ai'
+import repairToolPairing from '@/services/harness/compact/repair-tool-pairing'
+
+describe('repairToolPairing', () => {
+  it('drops a tool result with no matching assistant tool-call', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug.' },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            output: { type: 'text', value: 'dump' },
+          },
+        ],
+      },
+    ]
+
+    const repaired = repairToolPairing(messages)
+
+    expect(repaired).toEqual([{ role: 'user', content: 'Find the auth bug.' }])
+  })
+
+  it('drops an assistant tool-call with no matching tool result', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug.' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            input: { path: 'login.ts' },
+          },
+        ],
+      },
+    ]
+
+    const repaired = repairToolPairing(messages)
+
+    expect(repaired).toEqual([{ role: 'user', content: 'Find the auth bug.' }])
+  })
+
+  it('keeps a matched tool-call and tool-result pair', () => {
+    const messages: ModelMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Reading login.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            input: { path: 'login.ts' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            output: { type: 'text', value: 'ok' },
+          },
+        ],
+      },
+    ]
+
+    expect(repairToolPairing(messages)).toEqual(messages)
+  })
+})

--- a/spec/src/services/harness/compact/run-compact-rewrite.test.ts
+++ b/spec/src/services/harness/compact/run-compact-rewrite.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LanguageModel, ModelMessage, ToolSet } from 'ai'
+import type { ModelRef } from '@/types/models/model-ref'
+import { estimatePromptTokens } from '@/services/harness/compact'
+
+const generateCheckpoint = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+)
+
+vi.mock('@/services/harness/compact/generate-checkpoint', () => ({
+  default: (...args: unknown[]) => generateCheckpoint(...args),
+}))
+
+import runCompactRewrite from '@/services/harness/compact/run-compact-rewrite'
+
+const model = { id: 'chat-model' } as unknown as LanguageModel
+const modelRef: ModelRef = { providerId: 'local', modelId: 'qwen' }
+const tools: ToolSet = {}
+const hugeContent = 'x'.repeat(800_000)
+const system = 'You are the parent agent.'
+const highWater = 20_000
+
+const checkpointInput = (messages: ModelMessage[], signal = new AbortController().signal) => ({
+  model,
+  modelRef,
+  system,
+  providerOptions: {},
+  tools,
+  messages,
+  focus: 'parent',
+  signal,
+})
+
+describe('runCompactRewrite', () => {
+  beforeEach(() => {
+    generateCheckpoint.mockReset()
+  })
+
+  it('returns the model summary when generation succeeds and the rewrite fits', async () => {
+    generateCheckpoint.mockResolvedValue({
+      summary: 'Short recap',
+      usage: { inputTokens: 2, outputTokens: 1 },
+      providerMetadata: undefined,
+      responseId: 'r1',
+      modelRef,
+    })
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug.' },
+      { role: 'assistant', content: hugeContent },
+    ]
+
+    const result = await runCompactRewrite({
+      checkpointInput: checkpointInput(messages),
+      system,
+      messages,
+      highWater,
+    })
+
+    expect(result.summary).toBe('Short recap')
+    expect(result.compacted?.responseId).toBe('r1')
+    expect(estimatePromptTokens(system, result.messages)).toBeLessThanOrEqual(
+      highWater,
+    )
+  })
+
+  it('falls back when checkpoint generation fails', async () => {
+    generateCheckpoint.mockRejectedValue(new Error('prompt is too long'))
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug.' },
+      { role: 'assistant', content: hugeContent },
+    ]
+
+    const result = await runCompactRewrite({
+      checkpointInput: checkpointInput(messages),
+      system,
+      messages,
+      highWater,
+    })
+
+    expect(result.compacted).toBeNull()
+    expect(result.summary).toContain('Deterministic compaction fallback')
+    expect(estimatePromptTokens(system, result.messages)).toBeLessThanOrEqual(
+      highWater,
+    )
+  })
+
+  it('keeps the paid checkpoint when a huge model summary overflows and fallback persists', async () => {
+    generateCheckpoint.mockResolvedValue({
+      summary: 'M'.repeat(800_000),
+      usage: { inputTokens: 40, outputTokens: 20 },
+      providerMetadata: { paid: true },
+      responseId: 'r-paid',
+      modelRef,
+    })
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug.' },
+      { role: 'assistant', content: 'Inspecting token refresh.' },
+    ]
+
+    const result = await runCompactRewrite({
+      checkpointInput: checkpointInput(messages),
+      system,
+      messages,
+      highWater,
+    })
+
+    expect(result.summary).toContain('Deterministic compaction fallback')
+    expect(result.compacted?.responseId).toBe('r-paid')
+    expect(result.compacted?.usage).toEqual({
+      inputTokens: 40,
+      outputTokens: 20,
+    })
+    expect(estimatePromptTokens(system, result.messages)).toBeLessThanOrEqual(
+      highWater,
+    )
+  })
+
+  it('skips a doomed checkpoint request when the prompt is already over the hard window', async () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: hugeContent },
+    ]
+
+    const result = await runCompactRewrite({
+      checkpointInput: checkpointInput(messages),
+      system,
+      messages,
+      highWater,
+      hardWindow: 1_000,
+    })
+
+    expect(generateCheckpoint).not.toHaveBeenCalled()
+    expect(result.compacted).toBeNull()
+    expect(result.summary).toContain('Deterministic compaction fallback')
+    expect(estimatePromptTokens(system, result.messages)).toBeLessThanOrEqual(
+      highWater,
+    )
+  })
+
+  it('rethrows aborted checkpoint generation', async () => {
+    const controller = new AbortController()
+    generateCheckpoint.mockImplementation(async () => {
+      controller.abort()
+      throw new Error('aborted')
+    })
+    const messages: ModelMessage[] = [
+      { role: 'assistant', content: hugeContent },
+    ]
+
+    await expect(
+      runCompactRewrite({
+        checkpointInput: checkpointInput(messages, controller.signal),
+        system,
+        messages,
+        highWater,
+      }),
+    ).rejects.toThrow('aborted')
+  })
+})

--- a/spec/src/services/harness/orchestrator/prepare-compact-step.test.ts
+++ b/spec/src/services/harness/orchestrator/prepare-compact-step.test.ts
@@ -3,12 +3,14 @@ import type { LanguageModel, ModelMessage, ToolSet } from 'ai'
 import type { ModelRef } from '@/types/models/model-ref'
 import type { VixlSettings } from '@/types/vixl/vixl-settings'
 import type { HarnessEvent } from '@/types/harness/harness-event'
+import {
+  compactBudgets,
+  estimatePromptTokens,
+  resolveCompactHighWater,
+} from '@/services/harness/compact'
 
 const generateCheckpoint = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<unknown>>(),
-)
-const rewriteModelMessages = vi.hoisted(() =>
-  vi.fn<(...args: unknown[]) => ModelMessage[]>(),
 )
 const persistCompactionCheckpoint = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -19,10 +21,6 @@ const captureBillableUsage = vi.hoisted(() =>
 
 vi.mock('@/services/harness/compact/generate-checkpoint', () => ({
   default: (...args: unknown[]) => generateCheckpoint(...args),
-}))
-
-vi.mock('@/services/harness/compact/rewrite-model-messages', () => ({
-  default: (...args: unknown[]) => rewriteModelMessages(...args),
 }))
 
 vi.mock('@/services/harness/compact/persist-checkpoint', () => ({
@@ -67,18 +65,18 @@ const compactedResult = {
   modelRef: { providerId: 'openai', modelId: 'gpt-4o' },
 }
 
-const baseInput = () => {
+const baseInput = (overrides?: { settings?: VixlSettings; signal?: AbortSignal }) => {
   const onEvent = vi.fn<(event: HarnessEvent) => void>()
   return {
     onEvent,
     input: {
-      settings,
+      settings: overrides?.settings ?? settings,
       model: stubModel,
       modelRef: parentModelRef,
       system: 'You are the parent agent.',
       providerOptions: stubProviderOptions,
       tools: stubTools,
-      signal: new AbortController().signal,
+      signal: overrides?.signal ?? new AbortController().signal,
       workspace: { projectSlug: 'demo', projectRoot: '/tmp/demo', projectName: 'demo' },
       chatId: 'chat-1',
       turnId: 'turn-1',
@@ -88,16 +86,22 @@ const baseInput = () => {
   }
 }
 
+const expectPersistedUnderWindow = (
+  system: string,
+  messages: ModelMessage[],
+  usedSettings: VixlSettings = settings,
+) => {
+  expect(estimatePromptTokens(system, messages)).toBeLessThanOrEqual(
+    resolveCompactHighWater(usedSettings, parentModelRef),
+  )
+}
+
 describe('prepareParentCompactStep', () => {
   beforeEach(() => {
     generateCheckpoint.mockReset()
-    rewriteModelMessages.mockReset()
     persistCompactionCheckpoint.mockReset()
     captureBillableUsage.mockReset()
     generateCheckpoint.mockResolvedValue(compactedResult)
-    rewriteModelMessages.mockReturnValue([
-      { role: 'user', content: 'rewritten' },
-    ])
     persistCompactionCheckpoint.mockResolvedValue({
       summary: compactedResult.summary,
       includeFromCreatedAt: '2026-01-01T00:00:00.000Z',
@@ -164,9 +168,7 @@ describe('prepareParentCompactStep', () => {
       summary: compactedResult.summary,
       focus: 'parent',
     })
-    expect(onEvent).toHaveBeenCalledWith({
-      type: 'compaction-ended',
-    })
+    expect(onEvent).toHaveBeenCalledWith({ type: 'compaction-ended' })
     expect(onEvent.mock.calls[0]?.[0]).toEqual({ type: 'compaction-started' })
     expect(onEvent.mock.calls.at(-1)?.[0]).toEqual({ type: 'compaction-ended' })
     expect(onEvent).toHaveBeenCalledWith(
@@ -180,9 +182,12 @@ describe('prepareParentCompactStep', () => {
         }),
       }),
     )
-    expect(result).toEqual({
-      messages: [{ role: 'user', content: 'rewritten' }],
-    })
+    expect(result?.messages).toBeDefined()
+    expectPersistedUnderWindow(input.system, result?.messages ?? [])
+    const checkpoint = result?.messages?.[1]
+    expect(
+      checkpoint && 'content' in checkpoint ? checkpoint.content : '',
+    ).toContain(compactBudgets.CHECKPOINT_PREFIX)
   })
 
   it('still rewrites when billing fails after a successful compaction', async () => {
@@ -196,30 +201,226 @@ describe('prepareParentCompactStep', () => {
 
     const result = await prepareStep({ messages })
 
-    expect(result).toEqual({
-      messages: [{ role: 'user', content: 'rewritten' }],
-    })
+    expect(result?.messages).toBeDefined()
+    expectPersistedUnderWindow(input.system, result?.messages ?? [])
     expect(onEvent).toHaveBeenCalledWith({ type: 'compaction-ended' })
   })
 
-  it('emits compaction-ended when rewritten messages still exceed the window', async () => {
-    rewriteModelMessages.mockReturnValue([
-      { role: 'user', content: hugeContent },
-    ])
+  it('bounds an oversized first user message and persists activeContext', async () => {
+    const { input } = baseInput()
+    const prepareStep = prepareParentCompactStep(input)
+    const messages: ModelMessage[] = [{ role: 'user', content: hugeContent }]
+
+    const result = await prepareStep({ messages })
+
+    expect(persistCompactionCheckpoint).toHaveBeenCalledTimes(1)
+    expect(captureBillableUsage).toHaveBeenCalledTimes(1)
+    expect(result?.messages).toBeDefined()
+    expectPersistedUnderWindow(input.system, result?.messages ?? [])
+    expect(JSON.stringify(result?.messages)).not.toContain(hugeContent)
+  })
+
+  it('bounds a huge tool output and persists activeContext', async () => {
+    const { input } = baseInput()
+    const prepareStep = prepareParentCompactStep(input)
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug.' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            input: { path: 'login.ts' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            output: { type: 'text', value: hugeContent },
+          },
+        ],
+      },
+    ]
+
+    const result = await prepareStep({ messages })
+
+    expect(persistCompactionCheckpoint).toHaveBeenCalledTimes(1)
+    expect(result?.messages).toBeDefined()
+    expectPersistedUnderWindow(input.system, result?.messages ?? [])
+    expect(JSON.stringify(result?.messages)).not.toContain(hugeContent)
+    const rewritten = result?.messages ?? []
+    const callIds = rewritten.flatMap((message) =>
+      message.role === 'assistant' && Array.isArray(message.content)
+        ? message.content
+            .filter((part) => part.type === 'tool-call')
+            .map((part) => part.toolCallId)
+        : [],
+    )
+    const resultIds = rewritten.flatMap((message) =>
+      message.role === 'tool' && Array.isArray(message.content)
+        ? message.content
+            .filter((part) => part.type === 'tool-result')
+            .map((part) => part.toolCallId)
+        : [],
+    )
+    expect(callIds.sort()).toEqual(resultIds.sort())
+  })
+
+  it('bills a successful checkpoint when the rewrite falls back to a deterministic summary', async () => {
+    generateCheckpoint.mockResolvedValue({
+      ...compactedResult,
+      summary: 'M'.repeat(800_000),
+    })
+    const { input } = baseInput()
+    const prepareStep = prepareParentCompactStep(input)
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug.' },
+      { role: 'assistant', content: hugeContent },
+    ]
+
+    const result = await prepareStep({ messages })
+
+    expect(persistCompactionCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.stringContaining('Deterministic compaction fallback'),
+      }),
+    )
+    expect(captureBillableUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'compaction',
+        providerId: compactedResult.modelRef.providerId,
+        modelId: compactedResult.modelRef.modelId,
+        responseId: compactedResult.responseId,
+      }),
+    )
+    expect(result?.messages).toBeDefined()
+    expectPersistedUnderWindow(input.system, result?.messages ?? [])
+  })
+
+  it('skips a doomed checkpoint request already over the hard window', async () => {
+    const tightSettings = {
+      version: 1,
+      'models.default': 'local::qwen',
+      'providers.custom.local': {
+        type: 'openai-compatible',
+        name: 'Local',
+        baseURL: 'http://127.0.0.1:11434/v1',
+        models: [{ id: 'qwen', contextWindow: 50_000 }],
+      },
+    } as VixlSettings
+    const { input } = baseInput({ settings: tightSettings })
+    const prepareStep = prepareParentCompactStep(input)
+
+    const result = await prepareStep({
+      messages: [{ role: 'user', content: hugeContent }],
+    })
+
+    expect(generateCheckpoint).not.toHaveBeenCalled()
+    expect(captureBillableUsage).not.toHaveBeenCalled()
+    expect(persistCompactionCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.stringContaining('Deterministic compaction fallback'),
+      }),
+    )
+    expect(result?.messages).toBeDefined()
+    expectPersistedUnderWindow(
+      input.system,
+      result?.messages ?? [],
+      tightSettings,
+    )
+  })
+
+  it('uses a fallback checkpoint when generation fails and still persists', async () => {
+    generateCheckpoint.mockRejectedValue(new Error('prompt is too long'))
+    persistCompactionCheckpoint.mockResolvedValue({
+      summary: 'fallback',
+      includeFromCreatedAt: '2026-01-01T00:00:00.000Z',
+      checkpointLineId: 'cp-fallback',
+    })
     const { onEvent, input } = baseInput()
+    const prepareStep = prepareParentCompactStep(input)
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Find the auth bug.' },
+      { role: 'assistant', content: hugeContent },
+    ]
+
+    const result = await prepareStep({ messages })
+
+    expect(captureBillableUsage).not.toHaveBeenCalled()
+    expect(persistCompactionCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.stringContaining('Deterministic compaction fallback'),
+        focus: 'parent',
+      }),
+    )
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'compaction',
+        focus: 'parent',
+      }),
+    )
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'chat-meta-changed',
+        patch: expect.objectContaining({
+          activeContext: expect.objectContaining({
+            checkpointLineId: 'cp-fallback',
+          }),
+        }),
+      }),
+    )
+    expect(result?.messages).toBeDefined()
+    expectPersistedUnderWindow(input.system, result?.messages ?? [])
+  })
+
+  it('rethrows when checkpoint generation is aborted', async () => {
+    const controller = new AbortController()
+    generateCheckpoint.mockImplementation(async () => {
+      controller.abort()
+      throw new Error('aborted')
+    })
+    const { onEvent, input } = baseInput({ signal: controller.signal })
     const prepareStep = prepareParentCompactStep(input)
 
     await expect(
       prepareStep({
         messages: [{ role: 'assistant', content: hugeContent }],
       }),
+    ).rejects.toThrow('aborted')
+    expect(persistCompactionCheckpoint).not.toHaveBeenCalled()
+    expect(onEvent).toHaveBeenCalledWith({ type: 'compaction-ended' })
+  })
+
+  it('throws a specific error when even a bounded rewrite cannot fit', async () => {
+    const tinySettings = {
+      version: 1,
+      'models.default': 'local::qwen',
+      'providers.custom.local': {
+        type: 'openai-compatible',
+        name: 'Local',
+        baseURL: 'http://127.0.0.1:11434/v1',
+        models: [{ id: 'qwen', contextWindow: 80, maxOutputTokens: 40 }],
+      },
+    } as VixlSettings
+    const { onEvent, input } = baseInput({ settings: tinySettings })
+    const prepareStep = prepareParentCompactStep(input)
+
+    await expect(
+      prepareStep({
+        messages: [{ role: 'user', content: hugeContent }],
+      }),
     ).rejects.toThrow(
       'Parent context still exceeds the model window after compaction',
     )
+    expect(persistCompactionCheckpoint).not.toHaveBeenCalled()
     expect(onEvent).toHaveBeenCalledWith({ type: 'compaction-started' })
     expect(onEvent).toHaveBeenCalledWith({ type: 'compaction-ended' })
-    expect(onEvent).not.toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'compaction', focus: 'parent' }),
-    )
   })
 })

--- a/spec/src/services/harness/run-side-task.test.ts
+++ b/spec/src/services/harness/run-side-task.test.ts
@@ -153,16 +153,141 @@ describe('runSideTask chat title fallback', () => {
     )
   })
 
-  it('returns null without retry when primary passes quality-gate reject', async () => {
-    generateText.mockResolvedValueOnce({ text: 'New Agent' })
+  it('retries distinct fallback on empty output, then persists', async () => {
+    generateText
+      .mockResolvedValueOnce({ text: '   ' })
+      .mockResolvedValueOnce({ text: 'Auth Refactor' })
 
     const title = await runSideTask(baseInput())
+
+    expect(title).toBe('Auth Refactor')
+    expect(generateText).toHaveBeenCalledTimes(2)
+    expect(createModel).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        providerId: 'openai',
+        modelId: 'gpt-4o',
+      }),
+    )
+    expect(updateChatMeta).toHaveBeenCalledWith('proj', 'chat-1', {
+      title: 'Auth Refactor',
+    })
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('retries distinct fallback on default-title output, then persists', async () => {
+    generateText
+      .mockResolvedValueOnce({ text: 'New Agent' })
+      .mockResolvedValueOnce({ text: 'Auth Refactor' })
+
+    const title = await runSideTask(baseInput())
+
+    expect(title).toBe('Auth Refactor')
+    expect(generateText).toHaveBeenCalledTimes(2)
+    expect(updateChatMeta).toHaveBeenCalledWith('proj', 'chat-1', {
+      title: 'Auth Refactor',
+    })
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('retries distinct fallback on prompt-echo output and does not persist the echo', async () => {
+    generateText
+      .mockResolvedValueOnce({ text: 'Please refactor the auth module carefully' })
+      .mockResolvedValueOnce({ text: 'Auth Refactor' })
+
+    const title = await runSideTask(baseInput())
+
+    expect(title).toBe('Auth Refactor')
+    expect(generateText).toHaveBeenCalledTimes(2)
+    expect(updateChatMeta).toHaveBeenCalledWith('proj', 'chat-1', {
+      title: 'Auth Refactor',
+    })
+    expect(updateChatMeta).not.toHaveBeenCalledWith(
+      'proj',
+      'chat-1',
+      expect.objectContaining({
+        title: expect.stringMatching(/Please refactor/i),
+      }),
+    )
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('does not retry the same model when fallback matches primary', async () => {
+    generateText.mockResolvedValueOnce({ text: '' })
+
+    const title = await runSideTask({
+      ...baseInput(),
+      fallbackProviderId: 'ollama',
+      fallbackModelId: 'qwen',
+    })
 
     expect(title).toBeNull()
     expect(generateText).toHaveBeenCalledTimes(1)
     expect(createModel).toHaveBeenCalledTimes(1)
     expect(updateChatMeta).not.toHaveBeenCalled()
     expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('fails quietly when distinct fallback also fails the quality gate', async () => {
+    generateText
+      .mockResolvedValueOnce({ text: 'New Chat' })
+      .mockResolvedValueOnce({ text: 'New Agent' })
+
+    const title = await runSideTask(baseInput())
+
+    expect(title).toBeNull()
+    expect(generateText).toHaveBeenCalledTimes(2)
+    expect(updateChatMeta).not.toHaveBeenCalled()
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('passes shared no-reasoning call options for models that support none', async () => {
+    generateText.mockResolvedValueOnce({ text: 'Auth Refactor' })
+
+    const title = await runSideTask({
+      ...baseInput(),
+      settings: {
+        ...baseSettings(),
+        'models.title': 'openai::gpt-5.1',
+      },
+    })
+
+    expect(title).toBe('Auth Refactor')
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reasoning: 'none',
+        providerOptions: {
+          openai: {
+            reasoningEffort: 'none',
+          },
+        },
+      }),
+    )
+    expect(createModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: 'openai',
+        modelId: 'gpt-5.1',
+        disableThinking: true,
+      }),
+    )
+  })
+
+  it('omits reasoning on generateText when the model cannot disable it', async () => {
+    generateText.mockResolvedValueOnce({ text: 'Auth Refactor' })
+
+    await runSideTask({
+      ...baseInput(),
+      settings: {
+        ...baseSettings(),
+        'models.title': 'anthropic::claude-sonnet-4-6',
+      },
+    })
+
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reasoning: undefined,
+      }),
+    )
   })
 
   it('persists title on happy path with no toast', async () => {

--- a/spec/src/services/harness/subagent/prepare-compact-step.test.ts
+++ b/spec/src/services/harness/subagent/prepare-compact-step.test.ts
@@ -3,12 +3,14 @@ import type { LanguageModel, ModelMessage, ToolSet } from 'ai'
 import type { ModelRef } from '@/types/models/model-ref'
 import type { VixlSettings } from '@/types/vixl/vixl-settings'
 import type { HarnessEvent } from '@/types/harness/harness-event'
+import {
+  compactBudgets,
+  estimatePromptTokens,
+  resolveCompactHighWater,
+} from '@/services/harness/compact'
 
 const generateCheckpoint = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<unknown>>(),
-)
-const rewriteModelMessages = vi.hoisted(() =>
-  vi.fn<(...args: unknown[]) => ModelMessage[]>(),
 )
 const captureBillableUsage = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<void>>(),
@@ -16,10 +18,6 @@ const captureBillableUsage = vi.hoisted(() =>
 
 vi.mock('@/services/harness/compact/generate-checkpoint', () => ({
   default: (...args: unknown[]) => generateCheckpoint(...args),
-}))
-
-vi.mock('@/services/harness/compact/rewrite-model-messages', () => ({
-  default: (...args: unknown[]) => rewriteModelMessages(...args),
 }))
 
 vi.mock('@/services/billing/capture-billable-usage', () => ({
@@ -60,20 +58,20 @@ const compactedResult = {
   modelRef: { providerId: 'openai', modelId: 'gpt-4o' },
 }
 
-const baseInput = () => {
+const baseInput = (overrides?: { settings?: VixlSettings; signal?: AbortSignal }) => {
   const emitNestedEvent = vi.fn<(event: HarnessEvent) => void>()
   const onBillEvent = vi.fn<(event: HarnessEvent) => void>()
   return {
     emitNestedEvent,
     onBillEvent,
     input: {
-      settings,
+      settings: overrides?.settings ?? settings,
       model: stubModel,
       modelRef: childModelRef,
       system: 'You are a child subagent.',
       providerOptions: stubProviderOptions,
       tools: stubTools,
-      signal: new AbortController().signal,
+      signal: overrides?.signal ?? new AbortController().signal,
       projectSlug: 'demo',
       chatId: 'chat-1',
       turnId: 'turn-1',
@@ -87,12 +85,8 @@ const baseInput = () => {
 describe('prepareCompactStep', () => {
   beforeEach(() => {
     generateCheckpoint.mockReset()
-    rewriteModelMessages.mockReset()
     captureBillableUsage.mockReset()
     generateCheckpoint.mockResolvedValue(compactedResult)
-    rewriteModelMessages.mockReturnValue([
-      { role: 'user', content: 'rewritten' },
-    ])
     captureBillableUsage.mockResolvedValue(undefined)
   })
 
@@ -106,7 +100,6 @@ describe('prepareCompactStep', () => {
 
     expect(result).toBeUndefined()
     expect(generateCheckpoint).not.toHaveBeenCalled()
-    expect(rewriteModelMessages).not.toHaveBeenCalled()
     expect(captureBillableUsage).not.toHaveBeenCalled()
     expect(emitNestedEvent).not.toHaveBeenCalled()
   })
@@ -132,11 +125,6 @@ describe('prepareCompactStep', () => {
       focus: 'subagent',
       signal: input.signal,
     })
-
-    expect(rewriteModelMessages).toHaveBeenCalledWith(
-      messages,
-      compactedResult.summary,
-    )
     expect(emitNestedEvent).toHaveBeenCalledWith({
       type: 'compaction-started',
     })
@@ -146,12 +134,6 @@ describe('prepareCompactStep', () => {
       focus: 'subagent',
     })
     expect(emitNestedEvent).toHaveBeenCalledWith({
-      type: 'compaction-ended',
-    })
-    expect(emitNestedEvent.mock.calls[0]?.[0]).toEqual({
-      type: 'compaction-started',
-    })
-    expect(emitNestedEvent.mock.calls.at(-1)?.[0]).toEqual({
       type: 'compaction-ended',
     })
     expect(captureBillableUsage).toHaveBeenCalledWith(
@@ -170,9 +152,14 @@ describe('prepareCompactStep', () => {
         onEvent: onBillEvent,
       }),
     )
-    expect(result).toEqual({
-      messages: [{ role: 'user', content: 'rewritten' }],
-    })
+    expect(result?.messages).toBeDefined()
+    expect(estimatePromptTokens(input.system, result?.messages ?? [])).toBeLessThanOrEqual(
+      resolveCompactHighWater(settings, childModelRef),
+    )
+    const checkpoint = result?.messages?.[1]
+    expect(
+      checkpoint && 'content' in checkpoint ? checkpoint.content : '',
+    ).toContain(compactBudgets.CHECKPOINT_PREFIX)
   })
 
   it('still rewrites when billing fails after a successful compaction', async () => {
@@ -186,17 +173,136 @@ describe('prepareCompactStep', () => {
 
     const result = await prepareStep({ messages })
 
-    expect(result).toEqual({
-      messages: [{ role: 'user', content: 'rewritten' }],
-    })
+    expect(result?.messages).toBeDefined()
     expect(emitNestedEvent).toHaveBeenCalledWith({ type: 'compaction-ended' })
   })
 
-  it('throws when rewritten messages still exceed the window', async () => {
-    rewriteModelMessages.mockReturnValue([
-      { role: 'user', content: hugeContent },
-    ])
+  it('bounds an oversized first user message', async () => {
+    const { input } = baseInput()
+    const prepareStep = prepareCompactStep(input)
+
+    const result = await prepareStep({
+      messages: [{ role: 'user', content: hugeContent }],
+    })
+
+    expect(captureBillableUsage).toHaveBeenCalledTimes(1)
+    expect(result?.messages).toBeDefined()
+    expect(estimatePromptTokens(input.system, result?.messages ?? [])).toBeLessThanOrEqual(
+      resolveCompactHighWater(settings, childModelRef),
+    )
+  })
+
+  it('bounds a huge tool output', async () => {
+    const { input } = baseInput()
+    const prepareStep = prepareCompactStep(input)
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Spawn: find the auth bug.' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            input: { path: 'login.ts' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'read_file',
+            output: { type: 'text', value: hugeContent },
+          },
+        ],
+      },
+    ]
+
+    const result = await prepareStep({ messages })
+
+    expect(result?.messages).toBeDefined()
+    expect(JSON.stringify(result?.messages)).not.toContain(hugeContent)
+    const rewritten = result?.messages ?? []
+    const callIds = rewritten.flatMap((message) =>
+      message.role === 'assistant' && Array.isArray(message.content)
+        ? message.content
+            .filter((part) => part.type === 'tool-call')
+            .map((part) => part.toolCallId)
+        : [],
+    )
+    const resultIds = rewritten.flatMap((message) =>
+      message.role === 'tool' && Array.isArray(message.content)
+        ? message.content
+            .filter((part) => part.type === 'tool-result')
+            .map((part) => part.toolCallId)
+        : [],
+    )
+    expect(callIds.sort()).toEqual(resultIds.sort())
+  })
+
+  it('bills a successful checkpoint when the rewrite falls back to a deterministic summary', async () => {
+    generateCheckpoint.mockResolvedValue({
+      ...compactedResult,
+      summary: 'M'.repeat(800_000),
+    })
+    const { input } = baseInput()
+    const prepareStep = prepareCompactStep(input)
+
+    const result = await prepareStep({
+      messages: [
+        { role: 'user', content: 'Spawn: find the auth bug.' },
+        { role: 'assistant', content: hugeContent },
+      ],
+    })
+
+    expect(captureBillableUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'compaction',
+        responseId: compactedResult.responseId,
+        subagentId: 'sub-1',
+      }),
+    )
+    expect(result?.messages).toBeDefined()
+  })
+
+  it('uses a fallback checkpoint when generation fails', async () => {
+    generateCheckpoint.mockRejectedValue(new Error('prompt is too long'))
     const { emitNestedEvent, input } = baseInput()
+    const prepareStep = prepareCompactStep(input)
+
+    const result = await prepareStep({
+      messages: [
+        { role: 'user', content: 'Spawn: find the auth bug.' },
+        { role: 'assistant', content: hugeContent },
+      ],
+    })
+
+    expect(captureBillableUsage).not.toHaveBeenCalled()
+    expect(emitNestedEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'compaction',
+        summary: expect.stringContaining('Deterministic compaction fallback'),
+        focus: 'subagent',
+      }),
+    )
+    expect(result?.messages).toBeDefined()
+  })
+
+  it('throws a specific error when even a bounded rewrite cannot fit', async () => {
+    const tinySettings = {
+      version: 1,
+      'models.default': 'local::qwen',
+      'providers.custom.local': {
+        type: 'openai-compatible',
+        name: 'Local',
+        baseURL: 'http://127.0.0.1:11434/v1',
+        models: [{ id: 'qwen', contextWindow: 80, maxOutputTokens: 40 }],
+      },
+    } as VixlSettings
+    const { emitNestedEvent, input } = baseInput({ settings: tinySettings })
     const prepareStep = prepareCompactStep(input)
 
     await expect(
@@ -206,7 +312,6 @@ describe('prepareCompactStep', () => {
     ).rejects.toThrow(
       'Subagent context still exceeds the model window after compaction',
     )
-    expect(generateCheckpoint).toHaveBeenCalledTimes(1)
     expect(captureBillableUsage).not.toHaveBeenCalled()
     expect(emitNestedEvent).toHaveBeenCalledWith({ type: 'compaction-started' })
     expect(emitNestedEvent).toHaveBeenCalledWith({ type: 'compaction-ended' })

--- a/spec/src/services/models/resolve-model-call-options.test.ts
+++ b/spec/src/services/models/resolve-model-call-options.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolveModelCallOptions } from '@/services/models/resolve-model-call-options'
+import {
+  resolveModelCallOptions,
+  resolveSideTaskCallOptions,
+} from '@/services/models/resolve-model-call-options'
 import toCachedInstructions from '@/services/models/to-cached-instructions'
 import type { VixlSettings } from '@/types/vixl/vixl-settings'
 
@@ -91,5 +94,48 @@ describe('resolveModelCallOptions prompt cache', () => {
       modelId: 'openai/gpt-5',
     })
     expect(options.providerOptions?.anthropic).toBeUndefined()
+  })
+})
+
+describe('resolveSideTaskCallOptions no-reasoning', () => {
+  it('requests none through shared call options when the model allows it', () => {
+    const openai = resolveSideTaskCallOptions(settings, {
+      providerId: 'openai',
+      modelId: 'gpt-5.1',
+    })
+    expect(openai.reasoning).toBe('none')
+    expect(openai.providerOptions?.openai).toEqual({
+      reasoningEffort: 'none',
+    })
+
+    const custom = resolveSideTaskCallOptions(
+      {
+        version: 1,
+        'providers.custom.local': {
+          type: 'openai-compatible',
+          name: 'Local',
+          baseURL: 'http://127.0.0.1:11434/v1',
+          models: [
+            {
+              id: 'qwen3',
+              supportsReasoningEffort: ['none', 'low', 'high'],
+            },
+          ],
+        },
+      } as VixlSettings,
+      { providerId: 'local', modelId: 'qwen3' },
+    )
+    expect(custom.reasoning).toBe('none')
+    expect(custom.providerOptions?.local).toEqual({
+      reasoningEffort: 'none',
+    })
+  })
+
+  it('omits none when the model does not support that effort', () => {
+    const options = resolveSideTaskCallOptions(settings, {
+      providerId: 'anthropic',
+      modelId: 'claude-sonnet-4-6',
+    })
+    expect(options.reasoning).toBeUndefined()
   })
 })

--- a/src/composables/agent-harness/apply-visible-context-event.ts
+++ b/src/composables/agent-harness/apply-visible-context-event.ts
@@ -1,0 +1,60 @@
+import { toast } from 'vue-sonner'
+import type { HarnessEvent } from '@/types/harness/harness-event'
+import canWriteVisibleContext from './can-write-visible-context'
+import lastStepUsageFromRecord from './last-step-usage-from-record'
+import type { AgentHarnessState } from './types'
+
+const refreshVisibleBudget = (state: AgentHarnessState): void => {
+  state.contextBudgetSync.refreshContextBudget().catch((error) => {
+    toast.error('Failed to refresh context usage', {
+      description: error instanceof Error ? error.message : 'Unknown error',
+    })
+  })
+}
+
+export default (state: AgentHarnessState, event: HarnessEvent): void => {
+  if (!canWriteVisibleContext(state)) {
+    return
+  }
+
+  const { contextUsage } = state
+
+  if (event.type === 'context-budget') {
+    contextUsage.setBudget({
+      modelId: event.modelId,
+      used: event.used,
+      promptUsed: event.promptUsed,
+      limit: event.limit,
+      reservedOutput: event.reservedOutput,
+      safetyBuffer: event.safetyBuffer,
+      free: event.free,
+      buckets: event.buckets,
+    })
+    return
+  }
+
+  if (event.type === 'context-usage') {
+    contextUsage.setLastStepUsage({
+      promptTokens: event.promptTokens,
+      inputTokens: event.inputTokens,
+      outputTokens: event.outputTokens,
+      cacheReadTokens: event.cacheReadTokens,
+      cacheWriteTokens: event.cacheWriteTokens,
+    })
+    refreshVisibleBudget(state)
+    return
+  }
+
+  if (event.type === 'billable-usage') {
+    const lastStep = lastStepUsageFromRecord(event.record)
+    if (lastStep) {
+      contextUsage.setLastStepUsage(lastStep)
+    }
+    return
+  }
+
+  if (event.type === 'compaction') {
+    contextUsage.clearLastStepUsage()
+    refreshVisibleBudget(state)
+  }
+}

--- a/src/composables/agent-harness/cache.ts
+++ b/src/composables/agent-harness/cache.ts
@@ -3,6 +3,7 @@ import formatUnknownError from '@/utils/format-unknown-error'
 import { makeHarnessKey } from './helpers'
 
 type CachedHarness = {
+  markDisposed: () => void
   dispose: () => Promise<void>
 }
 
@@ -44,13 +45,15 @@ export const dropAgentHarness = (projectSlug: string, chatId: string): void => {
   const key = makeHarnessKey(projectSlug, chatId)
   const existing = harnessCache.get(key)
   harnessCache.delete(key)
-  if (existing) {
-    existing.dispose().catch((error: unknown) => {
-      toast.error('Failed to stop chat session', {
-        description: formatUnknownError(error),
-      })
-    })
+  if (!existing) {
+    return
   }
+  existing.markDisposed()
+  existing.dispose().catch((error: unknown) => {
+    toast.error('Failed to stop chat session', {
+      description: formatUnknownError(error),
+    })
+  })
 }
 
 export const resetAgentHarnessCacheForTests = (): void => {

--- a/src/composables/agent-harness/can-write-visible-context.ts
+++ b/src/composables/agent-harness/can-write-visible-context.ts
@@ -1,0 +1,8 @@
+import type { AgentHarnessState } from './types'
+
+export default (state: AgentHarnessState): boolean => {
+  if (state.disposed.value) {
+    return false
+  }
+  return state.chatStore.isSessionActive(state.options.projectSlug, state.options.chatId)
+}

--- a/src/composables/agent-harness/events.ts
+++ b/src/composables/agent-harness/events.ts
@@ -1,4 +1,3 @@
-import { toast } from 'vue-sonner'
 import type { HarnessEvent } from '@/types/harness/harness-event'
 import type { ToolRun } from '@/types/harness/tool-run'
 import type { PendingApprovalView } from '@/services/harness/permission/gate'
@@ -6,7 +5,7 @@ import { mapMetaStatusToChatStatus } from '@/services/harness/orchestrator'
 import mapSubagentResultStatus from '@/utils/map-subagent-result-status'
 import mergeToolRunArgs from '@/utils/merge-tool-run-args'
 import toolArgsPath from '@/utils/tool-args-path'
-import lastStepUsageFromRecord from './last-step-usage-from-record'
+import applyVisibleContextEvent from './apply-visible-context-event'
 import rebindWorkspace from './rebind-workspace'
 import type { AgentHarnessState, AttentionHelpers } from './types'
 
@@ -33,8 +32,6 @@ export default (
     pendingApprovals,
     billableUsageRecords,
     turnUsageByTurnId,
-    contextUsage,
-    contextBudgetSync,
     compacting,
   } = state
 
@@ -215,41 +212,10 @@ export default (
       pendingApprovals.value = [...pendingApprovals.value, view]
       attention.setChatAttention('needs_approval')
     }
-    if (event.type === 'context-budget') {
-      contextUsage.setBudget({
-        modelId: event.modelId,
-        used: event.used,
-        promptUsed: event.promptUsed,
-        limit: event.limit,
-        reservedOutput: event.reservedOutput,
-        safetyBuffer: event.safetyBuffer,
-        free: event.free,
-        buckets: event.buckets,
-      })
-    }
-    if (event.type === 'context-usage') {
-      contextUsage.setLastStepUsage({
-        promptTokens: event.promptTokens,
-        inputTokens: event.inputTokens,
-        outputTokens: event.outputTokens,
-        cacheReadTokens: event.cacheReadTokens,
-        cacheWriteTokens: event.cacheWriteTokens,
-      })
-      // Recount from timeline so Conversation includes tool I/O from this step.
-      contextBudgetSync.refreshContextBudget().catch((error) => {
-        toast.error('Failed to refresh context usage', {
-          description: error instanceof Error ? error.message : 'Unknown error',
-        })
-      })
-    }
     if (event.type === 'billable-usage') {
       const existing = billableUsageRecords.value
       const without = existing.filter((entry) => entry.id !== event.record.id)
       billableUsageRecords.value = [...without, event.record]
-      const lastStep = lastStepUsageFromRecord(event.record)
-      if (lastStep) {
-        contextUsage.setLastStepUsage(lastStep)
-      }
     }
     if (event.type === 'turn-usage') {
       turnUsageByTurnId.value = {
@@ -282,13 +248,7 @@ export default (
     }
     if (event.type === 'compaction') {
       session.appendLocalCompaction(event.summary, event.focus)
-      contextUsage.clearLastStepUsage()
       compacting.value = false
-      contextBudgetSync.refreshContextBudget().catch((error) => {
-        toast.error('Failed to refresh context usage', {
-          description: error instanceof Error ? error.message : 'Unknown error',
-        })
-      })
     }
     if (event.type === 'turn-aborted') {
       status.value = 'ready'
@@ -298,6 +258,7 @@ export default (
     if (event.type === 'workspace-moved') {
       return rebindWorkspace(state, event)
     }
+    applyVisibleContextEvent(state, event)
   }
 
   return { handleEvent }

--- a/src/composables/agent-harness/index.ts
+++ b/src/composables/agent-harness/index.ts
@@ -80,6 +80,7 @@ const createAgentHarness = (options: AgentHarnessOptions) => {
     mcpAuthPollTimer: { current: null },
     sessionAllows: new Set<string>(),
     sessionDenies: new Set<string>(),
+    disposed: ref(false),
   }
 
   const attention = createHelpers(state)
@@ -153,6 +154,7 @@ const createAgentHarness = (options: AgentHarnessOptions) => {
     cancelQueued: lifecycle.cancelQueued,
     editQueued: lifecycle.editQueued,
     dispose: lifecycle.dispose,
+    markDisposed: lifecycle.markDisposed,
   }
 }
 

--- a/src/composables/agent-harness/lifecycle.ts
+++ b/src/composables/agent-harness/lifecycle.ts
@@ -122,7 +122,12 @@ export default (
   const editQueued = (id: string): QueuedChatMessage | undefined =>
     messageQueue.items.value.find((entry) => entry.id === id)
 
+  const markDisposed = (): void => {
+    state.disposed.value = true
+  }
+
   const dispose = async (): Promise<void> => {
+    markDisposed()
     await stop()
     messageQueue.clear()
   }
@@ -134,5 +139,6 @@ export default (
     cancelQueued,
     editQueued,
     dispose,
+    markDisposed,
   }
 }

--- a/src/composables/agent-harness/restore-usage.ts
+++ b/src/composables/agent-harness/restore-usage.ts
@@ -4,6 +4,7 @@ import type { BillableUsageRecord } from '@/types/billing/billable-usage-record'
 import type { TurnUsageAggregate } from '@/types/billing/turn-usage-aggregate'
 import aggregateTurnUsage from '@/services/billing/aggregate-turn-usage'
 import readUsageLedger from '@/services/billing/read-usage-ledger'
+import canWriteVisibleContext from './can-write-visible-context'
 import lastStepUsageFromRecord from './last-step-usage-from-record'
 import type { AgentHarnessState } from './types'
 
@@ -50,7 +51,7 @@ const aggregatesByTurnId = (
 
 export default (state: AgentHarnessState) => {
   const restoreUsageLedger = async (): Promise<void> => {
-    const { options, billableUsageRecords, turnUsageByTurnId, contextUsage, chatStore, status } =
+    const { options, billableUsageRecords, turnUsageByTurnId, contextUsage, status } =
       state
 
     try {
@@ -60,8 +61,7 @@ export default (state: AgentHarnessState) => {
       turnUsageByTurnId.value = aggregatesByTurnId(merged)
 
       const lastStep = latestMainLastStep(merged)
-      const isActive = chatStore.isSessionActive(options.projectSlug, options.chatId)
-      if (!lastStep || !isActive || status.value !== 'ready') {
+      if (!lastStep || !canWriteVisibleContext(state) || status.value !== 'ready') {
         return
       }
 

--- a/src/composables/agent-harness/session-ops.ts
+++ b/src/composables/agent-harness/session-ops.ts
@@ -8,6 +8,7 @@ import chatRouteFor from '@/utils/chat-route-for'
 import formatUnknownError from '@/utils/format-unknown-error'
 import router from '@/router'
 import { loadEffectiveSettings } from '@/services/config/vixl-config'
+import canWriteVisibleContext from './can-write-visible-context'
 import type { AgentHarnessState } from './types'
 
 type SessionOpsDeps = {
@@ -70,7 +71,9 @@ export default (state: AgentHarnessState, deps: SessionOpsDeps) => {
         includeFromCreatedAt: result.includeFromCreatedAt,
         summary: result.summary,
       })
-      contextUsage.clearLastStepUsage()
+      if (canWriteVisibleContext(state)) {
+        contextUsage.clearLastStepUsage()
+      }
       toast.success('Context compacted', {
         description: 'Conversation history has been summarized.',
       })

--- a/src/composables/agent-harness/session-ops.ts
+++ b/src/composables/agent-harness/session-ops.ts
@@ -75,7 +75,9 @@ export default (state: AgentHarnessState, deps: SessionOpsDeps) => {
         contextUsage.clearLastStepUsage()
       }
       toast.success('Context compacted', {
-        description: 'Conversation history has been summarized.',
+        description: result.usedFallback
+          ? 'A deterministic fallback summary was used.'
+          : 'Conversation history has been summarized.',
       })
     } catch (err) {
       toast.error('Compaction failed', {
@@ -108,6 +110,7 @@ export default (state: AgentHarnessState, deps: SessionOpsDeps) => {
 
     compacting.value = true
     let summary = ''
+    let usedFallback = false
     try {
       const compactResult = await compactSession({
         projectSlug: options.projectSlug,
@@ -123,6 +126,7 @@ export default (state: AgentHarnessState, deps: SessionOpsDeps) => {
         onEvent: deps.handleEvent,
       })
       summary = compactResult.summary
+      usedFallback = compactResult.usedFallback
       session.appendLocalCompaction(compactResult.summary, null)
       session.patchMetaActiveContext({
         checkpointLineId: compactResult.checkpointLineId,
@@ -167,7 +171,9 @@ export default (state: AgentHarnessState, deps: SessionOpsDeps) => {
 
       await router.push(chatRouteFor(options.projectSlug, newChat.id))
       toast.success('Handoff created', {
-        description: 'New chat opened with context from previous session.',
+        description: usedFallback
+          ? 'New chat opened with a deterministic fallback summary.'
+          : 'New chat opened with context from previous session.',
       })
     } catch (err) {
       toast.error('Handoff failed: could not create new chat', {

--- a/src/composables/agent-harness/types.ts
+++ b/src/composables/agent-harness/types.ts
@@ -64,6 +64,7 @@ export type AgentHarnessState = {
   mcpAuthPollTimer: { current: ReturnType<typeof setInterval> | null }
   sessionAllows: Set<string>
   sessionDenies: Set<string>
+  disposed: Ref<boolean>
 }
 
 export type AttentionHelpers = {

--- a/src/composables/chat-store/store.ts
+++ b/src/composables/chat-store/store.ts
@@ -1,6 +1,7 @@
 import { computed } from 'vue'
 import type { ChatMeta } from '@/types/chat/chat-meta'
 import type { VixlChatMode } from '@/types/vixl/vixl-settings'
+import useContextUsage from '@/composables/use-context-usage'
 import {
   createChat,
   listChats,
@@ -24,6 +25,7 @@ import rekeyChatSession from './rekey'
 import type { SessionMutations } from './types'
 
 const useChatStore = () => {
+  const contextUsage = useContextUsage()
   const meta = computed(() => getActiveSession()?.meta.value ?? null)
   const messages = computed(() => getActiveSession()?.messages.value ?? [])
   const timeline = computed(() => getActiveSession()?.timeline.value ?? [])
@@ -52,6 +54,7 @@ const useChatStore = () => {
   const selectChat = (projectSlug: string, chatIdValue: string): SessionMutations => {
     const session = getOrCreateSession(projectSlug, chatIdValue)
     activeKey.value = session.key
+    contextUsage.bindChat(chatIdValue)
     return bindSessionMutations(session)
   }
 
@@ -60,6 +63,7 @@ const useChatStore = () => {
     sessions.delete(key)
     if (activeKey.value === key) {
       activeKey.value = null
+      contextUsage.bindChat(null)
     }
   }
 
@@ -77,6 +81,8 @@ const useChatStore = () => {
   ): Promise<'keepLive' | 'warmIdle' | 'cold'> => {
     const session = getOrCreateSession(projectSlug, chatIdValue)
     activeKey.value = session.key
+
+    contextUsage.bindChat(chatIdValue)
 
     const keepLive =
       session.warm &&
@@ -148,6 +154,7 @@ const useChatStore = () => {
     session.editDraftText.value = ''
     session.warm = true
     activeKey.value = session.key
+    contextUsage.bindChat(record.id)
     return session.meta.value
   }
 
@@ -158,6 +165,7 @@ const useChatStore = () => {
 
   const clearChatState = (): void => {
     activeKey.value = null
+    contextUsage.bindChat(null)
   }
 
   const facade = createActiveSessionFacade()

--- a/src/composables/chat-store/store.ts
+++ b/src/composables/chat-store/store.ts
@@ -37,7 +37,7 @@ const useChatStore = () => {
     () => getActiveSession()?.editingMessageId.value ?? null,
   )
   const editDraftText = computed(() => getActiveSession()?.editDraftText.value ?? '')
-  const chatId = computed(() => meta.value?.id ?? null)
+  const chatId = computed(() => getActiveSession()?.chatId ?? null)
   const todos = computed(() => todosFromTimeline(timeline.value))
 
   const forChat = (projectSlug: string, chatIdValue: string): SessionMutations =>

--- a/src/composables/use-chat-context-budget-sync.ts
+++ b/src/composables/use-chat-context-budget-sync.ts
@@ -108,34 +108,44 @@ export default () => {
   }
 
   const refreshContextBudget = async (): Promise<void> => {
+    const meta = chatStore.meta.value
+    const chatId = meta?.id ?? null
+
     if (chatStore.loading.value) {
+      contextUsage.bindChat(chatId)
       return
     }
 
-    const meta = chatStore.meta.value
+    if (!meta) {
+      contextUsage.bindChat(null)
+      return
+    }
+
     const modelId =
       draftModelRef.value ||
-      (meta?.model ? normalizeStoredModelRef(meta.model) ?? meta.model : '') ||
+      (meta.model ? normalizeStoredModelRef(meta.model) ?? meta.model : '') ||
       ''
     if (!modelId) {
+      contextUsage.bindChat(chatId)
       return
     }
 
-    const mode = draftMode.value || meta?.mode || 'agent'
+    const mode = draftMode.value || meta.mode || 'agent'
     const project = fleet.activeProject.value
-    const standalone = meta?.projectSlug === HOME_CHAT_SLUG
+    const standalone = meta.projectSlug === HOME_CHAT_SLUG
     const projectRoot = standalone
-      ? meta?.projectRoot
-      : project?.rootPath ?? meta?.projectRoot
+      ? meta.projectRoot
+      : project?.rootPath ?? meta.projectRoot
     if (!projectRoot) {
+      contextUsage.bindChat(chatId)
       return
     }
 
     const projectName = standalone
       ? 'Home'
-      : project?.name ?? meta?.projectSlug ?? 'Home'
+      : project?.name ?? meta.projectSlug ?? 'Home'
 
-    const frozenSnapshot = meta ? getFrozenPrefix(meta) : null
+    const frozenSnapshot = getFrozenPrefix(meta)
     const timeline = chatStore.timeline.value
     const messages = chatStore.messages.value
 
@@ -150,8 +160,8 @@ export default () => {
       standalone,
       frozenSnapshot,
       mentions: draftMentions.value,
-      activeContext: meta?.activeContext ?? null,
-      chatId: meta?.id,
+      activeContext: meta.activeContext ?? null,
+      chatId,
     })
   }
 

--- a/src/composables/use-chat-context-budget-sync.ts
+++ b/src/composables/use-chat-context-budget-sync.ts
@@ -112,7 +112,9 @@ export default () => {
     const chatId = meta?.id ?? null
 
     if (chatStore.loading.value) {
-      contextUsage.bindChat(chatId)
+      if (chatId) {
+        contextUsage.bindChat(chatId)
+      }
       return
     }
 

--- a/src/composables/use-chat-context-budget-sync.ts
+++ b/src/composables/use-chat-context-budget-sync.ts
@@ -109,17 +109,21 @@ export default () => {
 
   const refreshContextBudget = async (): Promise<void> => {
     const meta = chatStore.meta.value
-    const chatId = meta?.id ?? null
+    const selectedChatId = chatStore.chatId.value ?? meta?.id ?? null
 
     if (chatStore.loading.value) {
-      if (chatId) {
-        contextUsage.bindChat(chatId)
+      if (selectedChatId) {
+        contextUsage.bindChat(selectedChatId)
       }
       return
     }
 
-    if (!meta) {
+    if (!selectedChatId) {
       contextUsage.bindChat(null)
+      return
+    }
+
+    if (!meta) {
       return
     }
 
@@ -128,7 +132,7 @@ export default () => {
       (meta.model ? normalizeStoredModelRef(meta.model) ?? meta.model : '') ||
       ''
     if (!modelId) {
-      contextUsage.bindChat(chatId)
+      contextUsage.bindChat(selectedChatId)
       return
     }
 
@@ -139,7 +143,7 @@ export default () => {
       ? meta.projectRoot
       : project?.rootPath ?? meta.projectRoot
     if (!projectRoot) {
-      contextUsage.bindChat(chatId)
+      contextUsage.bindChat(selectedChatId)
       return
     }
 
@@ -163,7 +167,7 @@ export default () => {
       frozenSnapshot,
       mentions: draftMentions.value,
       activeContext: meta.activeContext ?? null,
-      chatId,
+      chatId: selectedChatId,
     })
   }
 
@@ -188,6 +192,7 @@ export default () => {
           () => chatStore.meta.value?.model,
           () => chatStore.meta.value?.mode,
           () => chatStore.meta.value?.prefixSnapshot?.hash,
+          () => chatStore.chatId.value,
           () => chatStore.meta.value?.id,
           () => chatStore.meta.value?.activeContext?.includeFromCreatedAt,
           () => chatStore.meta.value?.activeContext?.summary,

--- a/src/composables/use-context-usage.ts
+++ b/src/composables/use-context-usage.ts
@@ -43,7 +43,7 @@ export type RefreshContextUsageInput = {
   standalone?: boolean
   frozenSnapshot?: PrefixSnapshot | null
   activeContext?: ActiveContextSlice | null
-  chatId?: string
+  chatId?: string | null
 }
 
 export default () => {
@@ -81,12 +81,21 @@ export default () => {
     () => lastStepUsage.value?.inputTokens ?? null,
   )
 
+  const resetVisibleUsage = (): void => {
+    lastStepUsage.value = null
+    estimatedPromptUsed.value = 0
+    estimatedFree.value = 0
+    buckets.value = []
+    refreshGeneration += 1
+    pending.value = false
+  }
+
   const bindChat = (chatId: string | null): void => {
     if (boundChatId.value === chatId) {
       return
     }
     boundChatId.value = chatId
-    lastStepUsage.value = null
+    resetVisibleUsage()
   }
 
   const clearLastStepUsage = (): void => {
@@ -111,9 +120,7 @@ export default () => {
   }
 
   const refresh = async (input: RefreshContextUsageInput): Promise<void> => {
-    if (input.chatId !== undefined) {
-      bindChat(input.chatId)
-    }
+    bindChat(input.chatId ?? null)
 
     const generation = ++refreshGeneration
     pending.value = true

--- a/src/services/harness/compact-session.ts
+++ b/src/services/harness/compact-session.ts
@@ -1,3 +1,4 @@
+import { toast } from 'vue-sonner'
 import {
   convertToModelMessages,
   type LanguageModel,
@@ -13,8 +14,10 @@ import filterMessagesForActiveContext, {
   type FilteredActiveContextMessages,
 } from '@/services/context/filter-messages-for-active-context'
 import {
-  generateCheckpoint,
   persistCompactionCheckpoint,
+  resolveCompactHighWater,
+  resolveCompactWindow,
+  runCompactRewrite,
 } from '@/services/harness/compact'
 import resolveModelVision from '@/services/harness/resolve-model-vision'
 import { resolveSideTaskCallOptions } from '@/services/models/resolve-model-call-options'
@@ -44,6 +47,7 @@ export type CompactSessionResult = {
   summary: string
   includeFromCreatedAt: string
   checkpointLineId: string
+  usedFallback: boolean
 }
 
 const toNativePrefix = async (input: {
@@ -125,40 +129,60 @@ export default async (input: CompactSessionInput): Promise<CompactSessionResult>
     }
 
     const callOptions = resolveSideTaskCallOptions(settings, modelRef)
-    const compacted = await generateCheckpoint({
-      model,
-      modelRef,
+    const result = await runCompactRewrite({
+      checkpointInput: {
+        model,
+        modelRef,
+        system: frozenSystem ?? '',
+        providerOptions: callOptions.providerOptions,
+        tools: {},
+        messages: nativeMessages,
+        focus: focus ?? 'none',
+        signal: signal ?? new AbortController().signal,
+      },
       system: frozenSystem ?? '',
-      providerOptions: callOptions.providerOptions,
-      tools: {},
       messages: nativeMessages,
-      focus: focus ?? 'none',
-      signal: signal ?? new AbortController().signal,
+      highWater: resolveCompactHighWater(settings, modelRef),
+      hardWindow: resolveCompactWindow(settings, modelRef),
     })
 
-    if (input.onEvent) {
-      await captureBillableUsage({
-        projectSlug,
-        chatId,
-        turnId: input.turnId ?? `session:${chatId}`,
-        source: 'compaction',
-        providerId: compacted.modelRef.providerId,
-        modelId: compacted.modelRef.modelId,
-        usage: compacted.usage,
-        providerMetadata: compacted.providerMetadata,
-        responseId: compacted.responseId,
-        settings,
-        onEvent: input.onEvent,
-      })
-    }
-
-    return persistCompactionCheckpoint({
+    const compacted = result.compacted
+    const checkpoint = await persistCompactionCheckpoint({
       projectSlug,
       chatId,
-      summary: compacted.summary,
+      summary: result.summary,
       focus,
       messages,
     })
+
+    if (input.onEvent && compacted) {
+      try {
+        await captureBillableUsage({
+          projectSlug,
+          chatId,
+          turnId: input.turnId ?? `session:${chatId}`,
+          source: 'compaction',
+          providerId: compacted.modelRef.providerId,
+          modelId: compacted.modelRef.modelId,
+          usage: compacted.usage,
+          providerMetadata: compacted.providerMetadata,
+          responseId: compacted.responseId,
+          settings,
+          onEvent: input.onEvent,
+        })
+      } catch (error) {
+        toast.error('Failed to record compaction usage', {
+          description:
+            error instanceof Error ? error.message : 'Unknown error',
+        })
+      }
+    }
+
+    return {
+      ...checkpoint,
+      usedFallback:
+        compacted === null || result.summary !== compacted.summary,
+    }
   } catch (error) {
     throw new Error(formatUnknownError(error))
   }

--- a/src/services/harness/compact/bound-rewritten-messages.ts
+++ b/src/services/harness/compact/bound-rewritten-messages.ts
@@ -1,0 +1,89 @@
+import type { ModelMessage } from 'ai'
+import estimateTextTokens from '@/utils/estimate-text-tokens'
+import compactBudgets from './budgets'
+import { estimatePromptTokens } from './prompt-high-water'
+import repairToolPairing from './repair-tool-pairing'
+import truncateModelMessage from './truncate-model-message'
+
+const MIN_MESSAGE_TOKENS = 32
+
+const isCheckpoint = (message: ModelMessage): boolean =>
+  typeof message.content === 'string' &&
+  message.content.startsWith(compactBudgets.CHECKPOINT_PREFIX)
+
+const messageTokens = (message: ModelMessage): number =>
+  estimateTextTokens(JSON.stringify(message))
+
+const dropOldestTail = (messages: ModelMessage[]): ModelMessage[] | null => {
+  const checkpointIndex = messages.findIndex(isCheckpoint)
+  const dropIndex = checkpointIndex >= 0 ? checkpointIndex + 1 : 1
+  if (dropIndex <= 0 || dropIndex >= messages.length) {
+    return null
+  }
+  return messages.filter((_, index) => index !== dropIndex)
+}
+
+const shrinkLargest = (messages: ModelMessage[]): ModelMessage[] | null => {
+  let largestIndex = -1
+  let largestTokens = MIN_MESSAGE_TOKENS
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index]
+    if (!message) {
+      continue
+    }
+    const tokens = messageTokens(message)
+    if (tokens > largestTokens) {
+      largestIndex = index
+      largestTokens = tokens
+    }
+  }
+  if (largestIndex < 0) {
+    return null
+  }
+  const target = Math.max(MIN_MESSAGE_TOKENS, Math.floor(largestTokens / 2))
+  const current = messages[largestIndex]
+  if (!current) {
+    return null
+  }
+  const truncated = truncateModelMessage(current, target)
+  if (messageTokens(truncated) >= largestTokens) {
+    return null
+  }
+  return messages.map((message, index) =>
+    index === largestIndex ? truncated : message,
+  )
+}
+
+export default (
+  messages: ModelMessage[],
+  system: string,
+  highWater: number,
+): ModelMessage[] => {
+  let next = repairToolPairing(messages)
+
+  while (estimatePromptTokens(system, next) > highWater) {
+    const shrunk = shrinkLargest(next)
+    if (!shrunk) {
+      break
+    }
+    next = repairToolPairing(shrunk)
+  }
+
+  while (estimatePromptTokens(system, next) > highWater) {
+    const dropped = dropOldestTail(next)
+    if (!dropped) {
+      break
+    }
+    next = repairToolPairing(dropped)
+  }
+
+  while (estimatePromptTokens(system, next) > highWater) {
+    const shrunk = shrinkLargest(next)
+    if (!shrunk) {
+      break
+    }
+    next = repairToolPairing(shrunk)
+  }
+
+  return repairToolPairing(next)
+}

--- a/src/services/harness/compact/build-fallback-checkpoint.ts
+++ b/src/services/harness/compact/build-fallback-checkpoint.ts
@@ -1,0 +1,42 @@
+import type { ModelMessage } from 'ai'
+import modelMessageText from './model-message-text'
+
+const SNIPPET_CHARS = 1500
+const MAX_FALLBACK_CHARS = 4000
+
+const clip = (value: string, maxChars: number): string => {
+  if (value.length <= maxChars) {
+    return value
+  }
+  return `${value.slice(0, Math.max(0, maxChars - 16))}\n[truncated]`
+}
+
+export default (messages: ModelMessage[]): string => {
+  const firstUser = messages.find((message) => message.role === 'user')
+  const last = messages[messages.length - 1]
+  const roleCounts = messages.reduce(
+    (counts, message) => {
+      counts[message.role] = (counts[message.role] ?? 0) + 1
+      return counts
+    },
+    {} as Record<string, number>,
+  )
+  const roleSummary = Object.entries(roleCounts)
+    .map(([role, count]) => `${role}=${count}`)
+    .join(', ')
+
+  const lines = [
+    'Deterministic compaction fallback. Checkpoint generation failed or the rewritten prompt still exceeded the model window.',
+    `Message count: ${messages.length}. Roles: ${roleSummary}.`,
+  ]
+
+  if (firstUser) {
+    lines.push(`First user: ${clip(modelMessageText(firstUser), SNIPPET_CHARS)}`)
+  }
+
+  if (last && last !== firstUser) {
+    lines.push(`Latest: ${clip(modelMessageText(last), SNIPPET_CHARS)}`)
+  }
+
+  return clip(lines.join('\n'), MAX_FALLBACK_CHARS)
+}

--- a/src/services/harness/compact/index.ts
+++ b/src/services/harness/compact/index.ts
@@ -2,7 +2,10 @@ export { default as compactBudgets } from './budgets'
 export { default as generateCheckpoint } from './generate-checkpoint'
 export { default as rewriteModelMessages } from './rewrite-model-messages'
 export { default as persistCompactionCheckpoint } from './persist-checkpoint'
+export { default as runCompactRewrite } from './run-compact-rewrite'
+export { default as stillExceedsMessage } from './still-exceeds-message'
 export {
   estimatePromptTokens,
   resolveCompactHighWater,
+  resolveCompactWindow,
 } from './prompt-high-water'

--- a/src/services/harness/compact/model-message-text.ts
+++ b/src/services/harness/compact/model-message-text.ts
@@ -1,0 +1,12 @@
+import type { ModelMessage } from 'ai'
+
+export default (message: ModelMessage): string => {
+  if (typeof message.content === 'string') {
+    return message.content
+  }
+  try {
+    return JSON.stringify(message.content)
+  } catch {
+    return ''
+  }
+}

--- a/src/services/harness/compact/repair-tool-pairing.ts
+++ b/src/services/harness/compact/repair-tool-pairing.ts
@@ -1,0 +1,67 @@
+import type { ModelMessage } from 'ai'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const partToolCallId = (part: unknown, type: string): string | undefined => {
+  if (!isRecord(part) || part.type !== type) {
+    return undefined
+  }
+  return typeof part.toolCallId === 'string' ? part.toolCallId : undefined
+}
+
+const collectIds = (
+  messages: ModelMessage[],
+  role: 'assistant' | 'tool',
+  type: 'tool-call' | 'tool-result',
+): Set<string> => {
+  const ids = new Set<string>()
+  for (const message of messages) {
+    if (message.role !== role || !Array.isArray(message.content)) {
+      continue
+    }
+    for (const part of message.content) {
+      const id = partToolCallId(part, type)
+      if (id) {
+        ids.add(id)
+      }
+    }
+  }
+  return ids
+}
+
+export default (messages: ModelMessage[]): ModelMessage[] => {
+  const callIds = collectIds(messages, 'assistant', 'tool-call')
+  const resultIds = collectIds(messages, 'tool', 'tool-result')
+  const paired = new Set([...callIds].filter((id) => resultIds.has(id)))
+
+  const next: ModelMessage[] = []
+  for (const message of messages) {
+    if (message.role === 'tool' && Array.isArray(message.content)) {
+      const content = message.content.filter((part) => {
+        const id = partToolCallId(part, 'tool-result')
+        return id ? paired.has(id) : true
+      })
+      if (content.length === 0) {
+        continue
+      }
+      next.push({ ...message, content })
+      continue
+    }
+
+    if (message.role === 'assistant' && Array.isArray(message.content)) {
+      const content = message.content.filter((part) => {
+        const id = partToolCallId(part, 'tool-call')
+        return id ? paired.has(id) : true
+      })
+      if (content.length === 0) {
+        continue
+      }
+      next.push({ ...message, content })
+      continue
+    }
+
+    next.push(message)
+  }
+  return next
+}

--- a/src/services/harness/compact/run-compact-rewrite.ts
+++ b/src/services/harness/compact/run-compact-rewrite.ts
@@ -1,0 +1,86 @@
+import type { ModelMessage } from 'ai'
+import type {
+  GenerateCheckpointInput,
+  GenerateCheckpointResult,
+} from '@/types/harness/generate-checkpoint'
+import boundRewrittenMessages from './bound-rewritten-messages'
+import buildFallbackCheckpoint from './build-fallback-checkpoint'
+import generateCheckpoint from './generate-checkpoint'
+import { estimatePromptTokens } from './prompt-high-water'
+import repairToolPairing from './repair-tool-pairing'
+import rewriteModelMessages from './rewrite-model-messages'
+import stillExceedsMessage from './still-exceeds-message'
+
+type RunCompactRewriteInput = {
+  checkpointInput: GenerateCheckpointInput
+  system: string
+  messages: ModelMessage[]
+  highWater: number
+  hardWindow?: number
+}
+
+type RunCompactRewriteResult = {
+  messages: ModelMessage[]
+  /** Summary written to activeContext / compaction events. */
+  summary: string
+  /** Paid checkpoint call, when one succeeded. May differ from summary. */
+  compacted: GenerateCheckpointResult | null
+}
+
+const rewriteMessages = (
+  messages: ModelMessage[],
+  summary: string,
+): ModelMessage[] =>
+  repairToolPairing(rewriteModelMessages(messages, summary))
+
+export default async (
+  input: RunCompactRewriteInput,
+): Promise<RunCompactRewriteResult> => {
+  let compacted: GenerateCheckpointResult | null = null
+  const estimated = estimatePromptTokens(input.system, input.messages)
+  const skipGenerate =
+    typeof input.hardWindow === 'number' && estimated > input.hardWindow
+
+  let summary: string
+  if (skipGenerate) {
+    summary = buildFallbackCheckpoint(input.messages)
+  } else {
+    try {
+      compacted = await generateCheckpoint(input.checkpointInput)
+      summary = compacted.summary
+    } catch (error) {
+      if (input.checkpointInput.signal.aborted) {
+        throw error
+      }
+      summary = buildFallbackCheckpoint(input.messages)
+    }
+  }
+
+  let rewritten = rewriteMessages(input.messages, summary)
+  let rewrittenEstimate = estimatePromptTokens(input.system, rewritten)
+
+  if (rewrittenEstimate > input.highWater && compacted) {
+    const fallbackSummary = buildFallbackCheckpoint(input.messages)
+    const fallbackRewritten = rewriteMessages(input.messages, fallbackSummary)
+    const fallbackEstimate = estimatePromptTokens(
+      input.system,
+      fallbackRewritten,
+    )
+    if (fallbackEstimate < rewrittenEstimate) {
+      summary = fallbackSummary
+      rewritten = fallbackRewritten
+      rewrittenEstimate = fallbackEstimate
+    }
+  }
+
+  if (rewrittenEstimate > input.highWater) {
+    rewritten = boundRewrittenMessages(rewritten, input.system, input.highWater)
+    rewrittenEstimate = estimatePromptTokens(input.system, rewritten)
+  }
+
+  if (rewrittenEstimate > input.highWater) {
+    throw new Error(stillExceedsMessage(input.checkpointInput.focus))
+  }
+
+  return { messages: rewritten, summary, compacted }
+}

--- a/src/services/harness/compact/still-exceeds-message.ts
+++ b/src/services/harness/compact/still-exceeds-message.ts
@@ -1,0 +1,4 @@
+export default (focus: string): string =>
+  focus === 'subagent'
+    ? 'Subagent context still exceeds the model window after compaction'
+    : 'Parent context still exceeds the model window after compaction'

--- a/src/services/harness/compact/truncate-model-message.ts
+++ b/src/services/harness/compact/truncate-model-message.ts
@@ -1,0 +1,117 @@
+import type {
+  ModelMessage,
+  ToolCallPart,
+  ToolContent,
+  ToolResultPart,
+} from 'ai'
+import estimateTextTokens from '@/utils/estimate-text-tokens'
+import modelMessageText from './model-message-text'
+
+const CHARS_PER_TOKEN = 4
+const TRUNCATION_SUFFIX = '\n[truncated for compaction]'
+
+const clip = (value: string, maxChars: number): string => {
+  if (value.length <= maxChars) {
+    return value
+  }
+  const sliceLen = Math.max(0, maxChars - TRUNCATION_SUFFIX.length)
+  return `${value.slice(0, sliceLen)}${TRUNCATION_SUFFIX}`
+}
+
+const truncateOutput = (
+  output: ToolResultPart['output'],
+  maxChars: number,
+): ToolResultPart['output'] => {
+  if (output.type === 'text') {
+    return { type: 'text', value: clip(output.value, maxChars) }
+  }
+  return { type: 'text', value: clip(JSON.stringify(output), maxChars) }
+}
+
+const truncateToolResult = (
+  part: ToolResultPart,
+  maxChars: number,
+): ToolResultPart => ({
+  ...part,
+  output: truncateOutput(part.output, maxChars),
+})
+
+const truncateToolCall = (
+  part: ToolCallPart,
+  maxChars: number,
+): ToolCallPart => {
+  const inputRaw = JSON.stringify(part.input ?? {})
+  if (inputRaw.length <= maxChars) {
+    return part
+  }
+  return { ...part, input: { truncated: clip(inputRaw, maxChars) } }
+}
+
+const truncateToolContent = (
+  content: ToolContent,
+  maxChars: number,
+): ToolContent =>
+  content.map((part) => {
+    if (part.type === 'tool-result') {
+      return truncateToolResult(part, maxChars)
+    }
+    return part
+  })
+
+export default (message: ModelMessage, maxTokens: number): ModelMessage => {
+  const serialized = JSON.stringify(message)
+  if (estimateTextTokens(serialized) <= maxTokens) {
+    return message
+  }
+
+  const maxChars = Math.max(0, maxTokens * CHARS_PER_TOKEN)
+  const raw = modelMessageText(message)
+  const overhead = Math.max(0, serialized.length - raw.length)
+  const contentChars = Math.max(0, maxChars - overhead)
+
+  if (message.role === 'system') {
+    return { ...message, content: clip(message.content, contentChars) }
+  }
+
+  if (message.role === 'tool') {
+    return {
+      ...message,
+      content: truncateToolContent(message.content, contentChars),
+    }
+  }
+
+  if (message.role === 'user') {
+    if (typeof message.content === 'string') {
+      return { ...message, content: clip(message.content, contentChars) }
+    }
+    return {
+      ...message,
+      content: message.content.map((part) => {
+        if (part.type === 'text') {
+          return { ...part, text: clip(part.text, contentChars) }
+        }
+        return part
+      }),
+    }
+  }
+
+  if (typeof message.content === 'string') {
+    return { ...message, content: clip(message.content, contentChars) }
+  }
+
+  return {
+    ...message,
+    content: message.content.map((part) => {
+      if (part.type === 'text') {
+        return { ...part, text: clip(part.text, contentChars) }
+      }
+      if (part.type === 'tool-result') {
+        return truncateToolResult(part, contentChars)
+      }
+      if (part.type === 'tool-call') {
+        return truncateToolCall(part, contentChars)
+      }
+      return part
+    }),
+  }
+}

--- a/src/services/harness/orchestrator/prepare-compact-step.ts
+++ b/src/services/harness/orchestrator/prepare-compact-step.ts
@@ -8,10 +8,10 @@ import type { ModelRef } from '@/types/models/model-ref'
 import captureBillableUsage from '@/services/billing/capture-billable-usage'
 import {
   estimatePromptTokens,
-  generateCheckpoint,
   persistCompactionCheckpoint,
-  rewriteModelMessages,
   resolveCompactHighWater,
+  resolveCompactWindow,
+  runCompactRewrite,
 } from '@/services/harness/compact'
 
 type PrepareParentCompactStepInput = {
@@ -44,35 +44,34 @@ export default (input: PrepareParentCompactStepInput) =>
 
     input.onEvent({ type: 'compaction-started' })
     try {
-      const compacted = await generateCheckpoint({
-        model: input.model,
-        modelRef,
+      const compactedRewrite = await runCompactRewrite({
+        checkpointInput: {
+          model: input.model,
+          modelRef,
+          system,
+          providerOptions: input.providerOptions,
+          tools: input.tools,
+          messages: options.messages,
+          focus: 'parent',
+          signal: input.signal,
+        },
         system,
-        providerOptions: input.providerOptions,
-        tools: input.tools,
         messages: options.messages,
-        focus: 'parent',
-        signal: input.signal,
+        highWater,
+        hardWindow: resolveCompactWindow(settings, modelRef),
       })
-      const rewritten = rewriteModelMessages(options.messages, compacted.summary)
-      const compactedEstimate = estimatePromptTokens(system, rewritten)
-      if (compactedEstimate > highWater) {
-        throw new Error(
-          'Parent context still exceeds the model window after compaction',
-        )
-      }
 
       const checkpoint = await persistCompactionCheckpoint({
         projectSlug: input.workspace.projectSlug,
         chatId: input.chatId,
-        summary: compacted.summary,
+        summary: compactedRewrite.summary,
         focus: 'parent',
         messages: input.messages,
       })
 
       input.onEvent({
         type: 'compaction',
-        summary: compacted.summary,
+        summary: compactedRewrite.summary,
         focus: 'parent',
       })
       input.onEvent({
@@ -88,32 +87,31 @@ export default (input: PrepareParentCompactStepInput) =>
         },
       })
 
-      try {
-        await captureBillableUsage({
-          projectSlug: input.workspace.projectSlug,
-          chatId: input.chatId,
-          turnId: input.turnId,
-          source: 'compaction',
-          providerId: compacted.modelRef.providerId,
-          modelId: compacted.modelRef.modelId,
-          usage: compacted.usage,
-          providerMetadata: compacted.providerMetadata,
-          responseId: compacted.responseId,
-          settings,
-          onEvent: input.onEvent,
-        })
-      } catch (error) {
-        // The rewrite is already applied, so an unexpected billing failure must
-        // not abort the turn. captureBillableUsage toasts its own known
-        // persist/enrich failures, so anything reaching here is unexpected:
-        // surface it once and keep going.
-        toast.error('Failed to record compaction usage', {
-          description:
-            error instanceof Error ? error.message : 'Unknown error',
-        })
+      const compacted = compactedRewrite.compacted
+      if (compacted) {
+        try {
+          await captureBillableUsage({
+            projectSlug: input.workspace.projectSlug,
+            chatId: input.chatId,
+            turnId: input.turnId,
+            source: 'compaction',
+            providerId: compacted.modelRef.providerId,
+            modelId: compacted.modelRef.modelId,
+            usage: compacted.usage,
+            providerMetadata: compacted.providerMetadata,
+            responseId: compacted.responseId,
+            settings,
+            onEvent: input.onEvent,
+          })
+        } catch (error) {
+          toast.error('Failed to record compaction usage', {
+            description:
+              error instanceof Error ? error.message : 'Unknown error',
+          })
+        }
       }
 
-      return { messages: rewritten }
+      return { messages: compactedRewrite.messages }
     } finally {
       input.onEvent({ type: 'compaction-ended' })
     }

--- a/src/services/harness/run-side-task.ts
+++ b/src/services/harness/run-side-task.ts
@@ -98,6 +98,7 @@ export default async (input: ChatTitleTaskInput): Promise<string | null> => {
       frequencyPenalty: callOptions.frequencyPenalty,
       presencePenalty: callOptions.presencePenalty,
       seed: callOptions.seed,
+      reasoning: callOptions.reasoning,
       providerOptions: callOptions.providerOptions,
       prompt: loadPrompt('side-tasks/chat-title.md', {
         prompt: truncateTitlePrompt(input.prompt),
@@ -141,20 +142,32 @@ export default async (input: ChatTitleTaskInput): Promise<string | null> => {
     return null
   }
 
+  const distinctFallback =
+    chatFallback !== null &&
+    modelRefKey(chatFallback) !== modelRefKey(primaryModel)
+      ? chatFallback
+      : null
+
   let title: string | null
+  let usedFallback = false
   try {
     title = await generateTitleWithModel(primaryModel)
   } catch (primaryError) {
-    const canRetry =
-      chatFallback !== null &&
-      modelRefKey(chatFallback) !== modelRefKey(primaryModel)
-
-    if (!canRetry) {
+    if (!distinctFallback) {
       return toastTitleFailure(primaryError)
     }
 
+    usedFallback = true
     try {
-      title = await generateTitleWithModel(chatFallback)
+      title = await generateTitleWithModel(distinctFallback)
+    } catch (fallbackError) {
+      return toastTitleFailure(fallbackError)
+    }
+  }
+
+  if (!title && distinctFallback && !usedFallback) {
+    try {
+      title = await generateTitleWithModel(distinctFallback)
     } catch (fallbackError) {
       return toastTitleFailure(fallbackError)
     }

--- a/src/services/harness/subagent/prepare-compact-step.ts
+++ b/src/services/harness/subagent/prepare-compact-step.ts
@@ -7,9 +7,9 @@ import type { HarnessEvent } from '@/types/harness/harness-event'
 import captureBillableUsage from '@/services/billing/capture-billable-usage'
 import {
   estimatePromptTokens,
-  generateCheckpoint,
-  rewriteModelMessages,
   resolveCompactHighWater,
+  resolveCompactWindow,
+  runCompactRewrite,
 } from '@/services/harness/compact'
 
 type PrepareCompactStepInput = {
@@ -39,57 +39,55 @@ export default (input: PrepareCompactStepInput) =>
 
     input.emitNestedEvent({ type: 'compaction-started' })
     try {
-      const compacted = await generateCheckpoint({
-        model: input.model,
-        modelRef,
+      const compactedRewrite = await runCompactRewrite({
+        checkpointInput: {
+          model: input.model,
+          modelRef,
+          system,
+          providerOptions: input.providerOptions,
+          tools: input.tools,
+          messages: options.messages,
+          focus: 'subagent',
+          signal: input.signal,
+        },
         system,
-        providerOptions: input.providerOptions,
-        tools: input.tools,
         messages: options.messages,
-        focus: 'subagent',
-        signal: input.signal,
+        highWater,
+        hardWindow: resolveCompactWindow(settings, modelRef),
       })
-      const rewritten = rewriteModelMessages(options.messages, compacted.summary)
-      const compactedEstimate = estimatePromptTokens(system, rewritten)
-      if (compactedEstimate > highWater) {
-        throw new Error(
-          'Subagent context still exceeds the model window after compaction',
-        )
-      }
 
       input.emitNestedEvent({
         type: 'compaction',
-        summary: compacted.summary,
+        summary: compactedRewrite.summary,
         focus: 'subagent',
       })
 
-      try {
-        await captureBillableUsage({
-          projectSlug: input.projectSlug,
-          chatId: input.chatId,
-          turnId: input.turnId,
-          source: 'compaction',
-          providerId: compacted.modelRef.providerId,
-          modelId: compacted.modelRef.modelId,
-          usage: compacted.usage,
-          providerMetadata: compacted.providerMetadata,
-          responseId: compacted.responseId,
-          subagentId: input.subagentId,
-          settings,
-          onEvent: input.onBillEvent,
-        })
-      } catch (error) {
-        // The rewrite is already applied, so an unexpected billing failure must
-        // not abort the turn. captureBillableUsage toasts its own known
-        // persist/enrich failures, so anything reaching here is unexpected:
-        // surface it once and keep going.
-        toast.error('Failed to record compaction usage', {
-          description:
-            error instanceof Error ? error.message : 'Unknown error',
-        })
+      const compacted = compactedRewrite.compacted
+      if (compacted) {
+        try {
+          await captureBillableUsage({
+            projectSlug: input.projectSlug,
+            chatId: input.chatId,
+            turnId: input.turnId,
+            source: 'compaction',
+            providerId: compacted.modelRef.providerId,
+            modelId: compacted.modelRef.modelId,
+            usage: compacted.usage,
+            providerMetadata: compacted.providerMetadata,
+            responseId: compacted.responseId,
+            subagentId: input.subagentId,
+            settings,
+            onEvent: input.onBillEvent,
+          })
+        } catch (error) {
+          toast.error('Failed to record compaction usage', {
+            description:
+              error instanceof Error ? error.message : 'Unknown error',
+          })
+        }
       }
 
-      return { messages: rewritten }
+      return { messages: compactedRewrite.messages }
     } finally {
       input.emitNestedEvent({ type: 'compaction-ended' })
     }


### PR DESCRIPTION
## Summary

Fix stale visible context after chat deletion or creation, gate late harness context writes, recover auto-compaction when checkpoint generation fails, and make chat title retries provider agnostic.

## Changes

- Reset visible context usage when the active chat changes or becomes null
- Prevent inactive or disposed harnesses from writing the visible context bar
- Add deterministic auto-compaction fallback with bounded rewrites and valid tool-call pairing
- Retry title generation only when a distinct fallback model exists

## How to Test

1. `npm run ci`
2. `cargo audit --file src-tauri/Cargo.lock`
3. `cargo test --manifest-path src-tauri/Cargo.toml`

## Screenshots (optional)

Not applicable.

## Linked Issues

None.

## Checklist

- [x] I read CONTRIBUTING.md and agree to the Code of Conduct
- [x] I tested these changes locally
- [x] Added/updated tests if needed
- [x] Updated README if needed
- [x] `npm run ci` passes
- [x] No breaking changes, or I documented them above