### PR TITLE
fix: normalize image attachments before provider upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vixl",
-  "version": "0.1.0-beta.5",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vixl",
-      "version": "0.1.0-beta.5",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.15",
@@ -51,6 +51,7 @@
         "@xterm/xterm": "^6.0.0",
         "ai": "^7.0.29",
         "ansi-to-vue3": "^0.1.2",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "3.4.13",
@@ -6704,6 +6705,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
@@ -9653,7 +9663,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10031,7 +10041,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10051,7 +10061,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -16641,6 +16651,12 @@
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@xterm/xterm": "^6.0.0",
     "ai": "^7.0.29",
     "ansi-to-vue3": "^0.1.2",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "3.4.13",

--- a/spec/src/composables/agent-harness/send.test.ts
+++ b/spec/src/composables/agent-harness/send.test.ts
@@ -15,6 +15,12 @@ const listConfiguredProviders = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => string[]>(() => ['openai']),
 )
 const toastError = vi.hoisted(() => vi.fn<(...args: unknown[]) => void>())
+const normalizeImageDataUrl = vi.hoisted(() =>
+  vi.fn<(args: { dataUrl: string; mediaType: string }) => Promise<{
+    dataUrl: string
+    mediaType: string
+  }>>(async (args) => args),
+)
 
 vi.mock('@/services/vixl/vixl-tauri', () =>
   mockVixlTauri({
@@ -63,6 +69,12 @@ vi.mock('vue-sonner', () => ({
   toast: {
     error: (...args: unknown[]) => toastError(...args),
   },
+}))
+
+vi.mock('@/utils/normalize-image-data-url', () => ({
+  default: (
+    args: { dataUrl: string; mediaType: string },
+  ) => normalizeImageDataUrl(args),
 }))
 
 import createSend from '@/composables/agent-harness/send'
@@ -565,5 +577,185 @@ describe('agent-harness send persist model/mode', () => {
       expect.objectContaining({ text: '   ' }),
     )
     expect(runOrchestrator).not.toHaveBeenCalled()
+  })
+
+  it('normalizes image data-url parts before appending them', async () => {
+    normalizeImageDataUrl.mockResolvedValueOnce({
+      dataUrl: 'data:image/png;base64,BBB',
+      mediaType: 'image/png',
+    })
+    const state = buildState()
+    const { send } = createSend(state, buildAttention(), {
+      handleEvent: vi.fn<(...args: unknown[]) => void>(),
+      persistPermission: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+      maybeDrainQueue: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+    })
+
+    await send({
+      text: 'look',
+      mode: 'agent',
+      model: 'openai::gpt-4o',
+      internal: true,
+      files: [
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,AAA',
+          filename: 'shot.png',
+        },
+      ],
+    })
+
+    expect(normalizeImageDataUrl).toHaveBeenCalledWith({
+      dataUrl: 'data:image/png;base64,AAA',
+      mediaType: 'image/png',
+    })
+    expect(state.session.appendLocalMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parts: [
+          { type: 'text', text: 'look' },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            url: 'data:image/png;base64,BBB',
+            filename: 'shot.png',
+          },
+        ],
+      }),
+    )
+  })
+
+  it('adjusts the filename extension when normalized media type changes', async () => {
+    normalizeImageDataUrl.mockResolvedValueOnce({
+      dataUrl: 'data:image/png;base64,BBB',
+      mediaType: 'image/png',
+    })
+    const state = buildState()
+    const { send } = createSend(state, buildAttention(), {
+      handleEvent: vi.fn<(...args: unknown[]) => void>(),
+      persistPermission: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+      maybeDrainQueue: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+    })
+
+    await send({
+      text: 'look',
+      mode: 'agent',
+      model: 'openai::gpt-4o',
+      internal: true,
+      files: [
+        {
+          type: 'file',
+          mediaType: 'image/webp',
+          url: 'data:image/webp;base64,AAA',
+          filename: 'shot.webp',
+        },
+      ],
+    })
+
+    expect(state.session.appendLocalMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parts: [
+          { type: 'text', text: 'look' },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            url: 'data:image/png;base64,BBB',
+            filename: 'shot.png',
+          },
+        ],
+      }),
+    )
+  })
+
+  it('leaves non-image file parts untouched', async () => {
+    const state = buildState()
+    const { send } = createSend(state, buildAttention(), {
+      handleEvent: vi.fn<(...args: unknown[]) => void>(),
+      persistPermission: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+      maybeDrainQueue: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+    })
+
+    await send({
+      text: 'look',
+      mode: 'agent',
+      model: 'openai::gpt-4o',
+      internal: true,
+      files: [
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          url: 'data:application/pdf;base64,AAA',
+          filename: 'notes.pdf',
+        },
+      ],
+    })
+
+    expect(normalizeImageDataUrl).not.toHaveBeenCalled()
+    expect(state.session.appendLocalMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parts: [
+          { type: 'text', text: 'look' },
+          {
+            type: 'file',
+            mediaType: 'application/pdf',
+            url: 'data:application/pdf;base64,AAA',
+            filename: 'notes.pdf',
+          },
+        ],
+      }),
+    )
+  })
+
+  it('bails out when aborted while normalizing images', async () => {
+    let resolveNormalize: (value: {
+      dataUrl: string
+      mediaType: string
+    }) => void = () => undefined
+    normalizeImageDataUrl.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveNormalize = resolve
+      }),
+    )
+    const state = buildState()
+    const { send } = createSend(state, buildAttention(), {
+      handleEvent: vi.fn<(...args: unknown[]) => void>(),
+      persistPermission: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+      maybeDrainQueue: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+    })
+
+    const sending = send({
+      text: 'look',
+      mode: 'agent',
+      model: 'openai::gpt-4o',
+      internal: true,
+      files: [
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,AAA',
+          filename: 'shot.png',
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(normalizeImageDataUrl).toHaveBeenCalled()
+      expect(state.abortController.value).not.toBeNull()
+    })
+    expect(state.status.value).toBe('submitted')
+
+    state.abortController.value?.abort()
+    state.status.value = 'ready'
+    resolveNormalize({
+      dataUrl: 'data:image/png;base64,BBB',
+      mediaType: 'image/png',
+    })
+    await sending
+
+    expect(state.session.appendLocalMessage).not.toHaveBeenCalled()
+    expect(state.session.startAgentTurn).not.toHaveBeenCalled()
+    expect(runOrchestrator).not.toHaveBeenCalled()
+    expect(state.status.value).toBe('ready')
+    expect(state.abortController.value).toBeNull()
   })
 })

--- a/spec/src/utils/normalize-image-data-url.test.ts
+++ b/spec/src/utils/normalize-image-data-url.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import imageCompression from 'browser-image-compression'
+import bytesToDataUrl from '@/utils/bytes-to-data-url'
+import normalizeImageDataUrl from '@/utils/normalize-image-data-url'
+
+vi.mock('browser-image-compression', () => ({
+  default: vi.fn<(file: File, options?: Record<string, unknown>) => Promise<File>>(),
+}))
+
+const PNG_DATA_URL = 'data:image/png;base64,AAAA'
+const WEBP_DATA_URL = 'data:image/webp;base64,AAAA'
+const JPEG_DATA_URL = 'data:image/jpeg;base64,AAAA'
+
+const stubFetchFile = (size: number, type: string): void => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      blob: async () => new Blob([new Uint8Array(size)], { type }),
+    })),
+  )
+}
+
+const stubImageBitmap = (width: number, height: number): void => {
+  vi.stubGlobal(
+    'createImageBitmap',
+    vi.fn(async () => ({
+      width,
+      height,
+      close: vi.fn<() => void>(),
+    })),
+  )
+}
+
+describe('normalize-image-data-url', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.mocked(imageCompression).mockReset()
+  })
+
+  it('returns input unchanged for non-image mediaType', async () => {
+    const input = {
+      dataUrl: 'data:text/plain;base64,QQ==',
+      mediaType: 'text/plain',
+    }
+    await expect(normalizeImageDataUrl(input)).resolves.toEqual(input)
+    expect(imageCompression).not.toHaveBeenCalled()
+  })
+
+  it('returns input unchanged for a non-data URL', async () => {
+    const input = {
+      dataUrl: 'https://example.com/shot.png',
+      mediaType: 'image/png',
+    }
+    await expect(normalizeImageDataUrl(input)).resolves.toEqual(input)
+    expect(imageCompression).not.toHaveBeenCalled()
+  })
+
+  it('returns png/jpeg input unchanged when size and dimensions are within limits', async () => {
+    stubFetchFile(1024, 'image/png')
+    stubImageBitmap(800, 600)
+
+    const input = { dataUrl: PNG_DATA_URL, mediaType: 'image/png' }
+    await expect(normalizeImageDataUrl(input)).resolves.toEqual(input)
+    expect(imageCompression).not.toHaveBeenCalled()
+
+    stubFetchFile(2048, 'image/jpeg')
+    stubImageBitmap(2000, 2000)
+    const jpeg = { dataUrl: JPEG_DATA_URL, mediaType: 'image/jpeg' }
+    await expect(normalizeImageDataUrl(jpeg)).resolves.toEqual(jpeg)
+    expect(imageCompression).not.toHaveBeenCalled()
+  })
+
+  it('calls the library for an oversize png and returns its output', async () => {
+    stubFetchFile(4 * 1024 * 1024, 'image/png')
+    stubImageBitmap(800, 600)
+
+    const compressedBytes = new Uint8Array([1, 2, 3, 4])
+    const compressed = new File([compressedBytes], 'out.png', {
+      type: 'image/jpeg',
+    })
+    vi.mocked(imageCompression).mockResolvedValue(compressed)
+
+    const result = await normalizeImageDataUrl({
+      dataUrl: PNG_DATA_URL,
+      mediaType: 'image/png',
+    })
+
+    expect(imageCompression).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(imageCompression).mock.calls[0]?.[1]).toMatchObject({
+      maxSizeMB: 3.75,
+      maxWidthOrHeight: 2000,
+      initialQuality: 0.8,
+      useWebWorker: true,
+      fileType: undefined,
+    })
+    expect(result).toEqual({
+      dataUrl: bytesToDataUrl(compressedBytes, 'image/jpeg'),
+      mediaType: 'image/jpeg',
+    })
+  })
+
+  it('forces fileType image/png for webp input', async () => {
+    stubFetchFile(512, 'image/webp')
+    stubImageBitmap(100, 100)
+
+    const compressedBytes = new Uint8Array([9, 8, 7])
+    const compressed = new File([compressedBytes], 'out.png', {
+      type: 'image/png',
+    })
+    vi.mocked(imageCompression).mockResolvedValue(compressed)
+
+    const result = await normalizeImageDataUrl({
+      dataUrl: WEBP_DATA_URL,
+      mediaType: 'image/webp',
+    })
+
+    expect(vi.mocked(imageCompression).mock.calls[0]?.[1]).toMatchObject({
+      fileType: 'image/png',
+    })
+    expect(result).toEqual({
+      dataUrl: bytesToDataUrl(compressedBytes, 'image/png'),
+      mediaType: 'image/png',
+    })
+  })
+
+  it('falls through to the library when createImageBitmap throws for a small png', async () => {
+    stubFetchFile(1024, 'image/png')
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => {
+        throw new Error('decode failed')
+      }),
+    )
+
+    const compressedBytes = new Uint8Array([5, 6])
+    const compressed = new File([compressedBytes], 'out.png', {
+      type: 'image/png',
+    })
+    vi.mocked(imageCompression).mockResolvedValue(compressed)
+
+    const result = await normalizeImageDataUrl({
+      dataUrl: PNG_DATA_URL,
+      mediaType: 'image/png',
+    })
+
+    expect(imageCompression).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      dataUrl: bytesToDataUrl(compressedBytes, 'image/png'),
+      mediaType: 'image/png',
+    })
+  })
+
+  it('returns the original input when the library throws', async () => {
+    stubFetchFile(4 * 1024 * 1024, 'image/png')
+    stubImageBitmap(800, 600)
+    vi.mocked(imageCompression).mockRejectedValue(new Error('compress failed'))
+
+    const input = { dataUrl: PNG_DATA_URL, mediaType: 'image/png' }
+    await expect(normalizeImageDataUrl(input)).resolves.toEqual(input)
+  })
+})

--- a/src/composables/agent-harness/send.ts
+++ b/src/composables/agent-harness/send.ts
@@ -15,6 +15,8 @@ import dropUnresolvedAgentMentions from '@/services/agents/drop-unresolved-agent
 import buildMentionHighlights from '@/utils/build-mention-highlights'
 import collectExplicitAgentMentions from '@/utils/collect-explicit-agent-mentions'
 import { loadEffectiveSettings } from '@/services/config/vixl-config'
+import filenameWithMediaTypeExtension from '@/utils/filename-with-media-type-extension'
+import normalizeImageDataUrl from '@/utils/normalize-image-data-url'
 import type { AgentHarnessState, AttentionHelpers } from './types'
 
 export type SendArgs = {
@@ -162,68 +164,99 @@ export default (
       })
     }
 
-    if (!args.skipUserMessage) {
-      const fileParts = args.files ?? []
-
-      const parts: Array<
-        | { type: 'text'; text: string }
-        | { type: 'file'; mediaType: string; url: string; filename?: string }
-      > = [{ type: 'text', text: args.text }]
-
-      // Always keep file parts on the UI message so the thread can show
-      // thumbnails. Non-vision models get text placeholders later, only for
-      // convertToModelMessages in the orchestrator.
-      for (const file of fileParts) {
-        const url = file.url
-        if (url?.startsWith('file://')) {
-          parts.push({
-            type: 'text',
-            text: `[Attachment unavailable: ${file.filename || url}]`,
-          })
-          continue
-        }
-
-        if (url) {
-          parts.push({
-            type: 'file',
-            mediaType: file.mediaType || 'image/png',
-            url,
-            filename: file.filename,
-          })
-        }
-      }
-
-      const skillNames = (
-        await listSlashSkillIndex(projectRoot).catch(() => [])
-      ).map((skill) => skill.name)
-      const agentNames = agentIndex.map((agent) => agent.name)
-
-      const mentionHighlights = buildMentionHighlights(
-        args.text,
-        mentions,
-        skillNames,
-        agentNames,
-      )
-
-      session.appendLocalMessage({
-        id: crypto.randomUUID(),
-        role: 'user',
-        parts,
-        metadata: {
-          createdAt: new Date().toISOString(),
-          model: args.model,
-          ...(mentionHighlights.length > 0 ? { mentionHighlights } : {}),
-        },
-      })
-    }
-
-    const turnId = crypto.randomUUID()
-    session.startAgentTurn(turnId)
-
     const controller = new AbortController()
     abortController.value = controller
 
     try {
+      if (!args.skipUserMessage) {
+        const fileParts = args.files ?? []
+
+        const parts: Array<
+          | { type: 'text'; text: string }
+          | { type: 'file'; mediaType: string; url: string; filename?: string }
+        > = [{ type: 'text', text: args.text }]
+
+        // Always keep file parts on the UI message so the thread can show
+        // thumbnails. Non-vision models get text placeholders later, only for
+        // convertToModelMessages in the orchestrator.
+        for (const file of fileParts) {
+          const url = file.url
+          if (url?.startsWith('file://')) {
+            parts.push({
+              type: 'text',
+              text: `[Attachment unavailable: ${file.filename || url}]`,
+            })
+            continue
+          }
+
+          if (!url) {
+            continue
+          }
+
+          let mediaType = file.mediaType || 'image/png'
+          let partUrl = url
+          let filename = file.filename
+          if (url.startsWith('data:') && mediaType.startsWith('image/')) {
+            const normalized = await normalizeImageDataUrl({
+              dataUrl: url,
+              mediaType,
+            })
+            if (normalized.mediaType !== mediaType) {
+              filename = filenameWithMediaTypeExtension(
+                filename,
+                normalized.mediaType,
+              )
+            }
+            mediaType = normalized.mediaType
+            partUrl = normalized.dataUrl
+          }
+          parts.push({
+            type: 'file',
+            mediaType,
+            url: partUrl,
+            filename,
+          })
+        }
+
+        if (controller.signal.aborted) {
+          status.value = 'ready'
+          await fleetSidebar.refreshSlug(options.projectSlug)
+          return
+        }
+
+        const skillNames = (
+          await listSlashSkillIndex(projectRoot).catch(() => [])
+        ).map((skill) => skill.name)
+        const agentNames = agentIndex.map((agent) => agent.name)
+
+        const mentionHighlights = buildMentionHighlights(
+          args.text,
+          mentions,
+          skillNames,
+          agentNames,
+        )
+
+        session.appendLocalMessage({
+          id: crypto.randomUUID(),
+          role: 'user',
+          parts,
+          metadata: {
+            createdAt: new Date().toISOString(),
+            model: args.model,
+            ...(mentionHighlights.length > 0 ? { mentionHighlights } : {}),
+          },
+        })
+      }
+
+      if (controller.signal.aborted) {
+        status.value = 'ready'
+        await fleetSidebar.refreshSlug(options.projectSlug)
+        return
+      }
+
+      const turnId = crypto.randomUUID()
+      session.startAgentTurn(turnId)
+
       await runOrchestrator({
         workspace: options,
         projectSlug: options.projectSlug,
@@ -262,6 +295,9 @@ export default (
         err instanceof Error &&
         (err.name === 'TimeoutError' || /timeout/i.test(err.message))
       const message = err instanceof Error ? err.message : 'Unknown error'
+      const payloadHint = /invalid json response body/i.test(message)
+        ? ' The provider rejected the request payload. Try smaller or fewer images.'
+        : ''
       if (aborted) {
         status.value = 'ready'
         session.finishAgentTurn()
@@ -276,14 +312,14 @@ export default (
           ? 'The model took too long to respond.'
           : message.includes('No output generated')
             ? 'The model returned an empty response. Check your API key and model ID in Settings.'
-            : message,
+            : `${message}${payloadHint}`,
       })
       session.finishAgentTurn()
       attention.applyTurnEndAttention('error')
       toast.error('Agent run failed', {
         description: error.value.includes('No output generated')
           ? 'The model returned an empty response. Check your Gateway API key and model ID in Settings.'
-          : error.value,
+          : `${error.value}${payloadHint}`,
       })
       await fleetSidebar.refreshSlug(options.projectSlug)
     } finally {

--- a/src/utils/filename-with-media-type-extension.ts
+++ b/src/utils/filename-with-media-type-extension.ts
@@ -1,0 +1,11 @@
+export default (
+  filename: string | undefined,
+  mediaType: string,
+): string | undefined => {
+  const lastDot = filename?.lastIndexOf('.') ?? -1
+  const extension = mediaType === 'image/jpeg' ? 'jpg' : mediaType.split('/')[1]
+  if (!filename || lastDot <= 0 || !extension) {
+    return filename
+  }
+  return `${filename.slice(0, lastDot)}.${extension}`
+}

--- a/src/utils/normalize-image-data-url.ts
+++ b/src/utils/normalize-image-data-url.ts
@@ -1,0 +1,72 @@
+import imageCompression from 'browser-image-compression'
+import bytesToDataUrl from '@/utils/bytes-to-data-url'
+
+// 3.75MB = 5MB base64 budget x 3/4. 2000px matches the Claude Code / OpenCode consensus.
+const MAX_SIZE_MB = 3.75
+const MAX_RAW_BYTES = MAX_SIZE_MB * 1024 * 1024
+const MAX_EDGE_PX = 2000
+
+const isProviderAcceptedImageType = (mediaType: string): boolean =>
+  mediaType === 'image/png' || mediaType === 'image/jpeg'
+
+const fileFromDataUrl = async (
+  dataUrl: string,
+  mediaType: string,
+): Promise<File> => {
+  const response = await fetch(dataUrl)
+  const blob = await response.blob()
+  return new File([blob], 'image', { type: mediaType })
+}
+
+const withinDimensionLimit = async (blob: Blob): Promise<boolean | null> => {
+  try {
+    const bitmap = await createImageBitmap(blob)
+    const within = bitmap.width <= MAX_EDGE_PX && bitmap.height <= MAX_EDGE_PX
+    bitmap.close()
+    return within
+  } catch {
+    return null
+  }
+}
+
+export default async (args: {
+  dataUrl: string
+  mediaType: string
+}): Promise<{ dataUrl: string; mediaType: string }> => {
+  const { dataUrl, mediaType } = args
+
+  if (!mediaType.startsWith('image/') || !dataUrl.startsWith('data:')) {
+    return args
+  }
+
+  try {
+    const file = await fileFromDataUrl(dataUrl, mediaType)
+    const keepNativeType = isProviderAcceptedImageType(mediaType)
+
+    if (keepNativeType && file.size <= MAX_RAW_BYTES) {
+      const dimensionsOk = await withinDimensionLimit(file)
+      if (dimensionsOk === true) {
+        return args
+      }
+    }
+
+    const fileType = keepNativeType ? undefined : 'image/png'
+    const compressed = await imageCompression(file, {
+      maxSizeMB: MAX_SIZE_MB,
+      maxWidthOrHeight: MAX_EDGE_PX,
+      initialQuality: 0.8,
+      useWebWorker: true,
+      fileType,
+    })
+
+    const bytes = new Uint8Array(await compressed.arrayBuffer())
+    const resultType = compressed.type || fileType || mediaType
+
+    return {
+      dataUrl: bytesToDataUrl(bytes, resultType),
+      mediaType: resultType,
+    }
+  } catch {
+    return args
+  }
+}


### PR DESCRIPTION
## Summary

Image attachments were sent to providers as unmodified base64 data URLs. z.ai (via AI Gateway) rejects oversized or unsupported image payloads at its edge with a plain-text body, which surfaced as `invalid json response body ... is not valid JSON` and failed the turn. This PR normalizes images client-side before send, matching the proven pipelines in Claude Code and OpenCode.

## Changes

- Add `browser-image-compression` (MIT, ~1.3M weekly downloads) and a thin `normalize-image-data-url` util: png/jpeg within 3.75MB and 2000px pass through unchanged, everything else is resized/re-encoded by the library, non-png/jpeg formats convert to png (z.ai only accepts jpg/png/jpeg), and any failure falls back to the original image
- Wire normalization into the send path in `agent-harness/send.ts`, adjusting filename extensions when the media type changes
- Create the send AbortController before normalization so Stop works while compression is in flight
- Add a short payload-rejection hint to the error toast/alert when the provider returns an invalid JSON response body

## How to Test

1. Attach two large screenshots to a chat with `zai/glm-5.3-flash` via AI Gateway and send
2. Confirm the turn completes instead of failing with an invalid JSON response body error

## Screenshots (optional)

N/A

## Linked Issues

N/A

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I tested these changes locally
- [x] Added/updated tests if needed
- [x] Updated README if needed
- [x] `npm run ci` passes (or `npm run lint` and `npm run type-check` at minimum)
- [x] No breaking changes, or I documented them above