### PR TITLE
fix: keep tauri update instance raw in updater state

### DIFF
--- a/spec/src/composables/use-app-updater.test.ts
+++ b/spec/src/composables/use-app-updater.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DownloadEvent } from '@tauri-apps/plugin-updater'
+import { mockVixlTauri } from '../test-utils/mocks/vixl-tauri'
+
+type FakeUpdate = {
+  version: string
+  body: string
+  downloadAndInstall: ReturnType<
+    typeof vi.fn<(onEvent?: (event: DownloadEvent) => void) => Promise<void>>
+  >
+}
+
+const check = vi.hoisted(() => vi.fn<() => Promise<FakeUpdate | null>>())
+const relaunch = vi.hoisted(() =>
+  vi.fn<() => Promise<void>>(async () => undefined),
+)
+
+vi.mock('@tauri-apps/plugin-updater', () => ({
+  check: () => check(),
+}))
+
+vi.mock('@tauri-apps/plugin-process', () => ({
+  relaunch: () => relaunch(),
+}))
+
+vi.mock('@/services/vixl/vixl-tauri', () => mockVixlTauri())
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    success: vi.fn<(...args: unknown[]) => void>(),
+    error: vi.fn<(...args: unknown[]) => void>(),
+  },
+}))
+
+const createFakeUpdate = (): FakeUpdate => ({
+  version: '1.2.3',
+  body: 'Release notes',
+  downloadAndInstall: vi.fn<
+    (onEvent?: (event: DownloadEvent) => void) => Promise<void>
+  >(async () => undefined),
+})
+
+describe('use-app-updater', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('DEV', false)
+    check.mockReset()
+    relaunch.mockReset()
+    relaunch.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('stores the check result as the same object, not a reactive proxy', async () => {
+    const fakeUpdate = createFakeUpdate()
+    check.mockResolvedValue(fakeUpdate)
+
+    const { default: useAppUpdater } = await import('@/composables/use-app-updater')
+    const updater = useAppUpdater()
+    await updater.checkForUpdates({ silent: true })
+
+    expect(updater.updateAvailable.value).toBe(fakeUpdate)
+  })
+
+  it('downloadAndInstall calls the update method then relaunch', async () => {
+    const fakeUpdate = createFakeUpdate()
+    check.mockResolvedValue(fakeUpdate)
+
+    const { default: useAppUpdater } = await import('@/composables/use-app-updater')
+    const updater = useAppUpdater()
+    await updater.checkForUpdates({ silent: true })
+    await updater.downloadAndInstall()
+
+    expect(fakeUpdate.downloadAndInstall).toHaveBeenCalledTimes(1)
+    expect(relaunch).toHaveBeenCalledTimes(1)
+  })
+
+  it('sets updateAvailable to null when check resolves null', async () => {
+    check.mockResolvedValue(null)
+
+    const { default: useAppUpdater } = await import('@/composables/use-app-updater')
+    const updater = useAppUpdater()
+    await updater.checkForUpdates({ silent: true })
+
+    expect(updater.updateAvailable.value).toBeNull()
+  })
+})

--- a/src/composables/use-app-updater.ts
+++ b/src/composables/use-app-updater.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { toast } from 'vue-sonner'
 import { check, type Update } from '@tauri-apps/plugin-updater'
 import { relaunch } from '@tauri-apps/plugin-process'
@@ -11,7 +11,7 @@ type UpdateProgress = {
 }
 
 const checking = ref(false)
-const updateAvailable = ref<Update | null>(null)
+const updateAvailable = shallowRef<Update | null>(null)
 const downloading = ref(false)
 const progress = ref<UpdateProgress | null>(null)
 const lastCheckedAt = ref<Date | null>(null)


### PR DESCRIPTION
## Summary

Installing an update from the in-app updater failed with `Cannot read private member from an object whose class did not declare it`. The `Update` instance from `@tauri-apps/plugin-updater` was stored in a `ref`, which deep-wraps it in a Vue reactive Proxy. Calling `downloadAndInstall()` on the proxy breaks private class field access. The instance is now stored in a `shallowRef`, so methods always run on the raw object.

## Changes

- `use-app-updater.ts`: `ref` to `shallowRef` for `updateAvailable`
- New regression spec asserting the stored update is the identical object returned by `check()` (fails with `ref`, passes with `shallowRef`), plus install and null-result coverage

## How to Test

1. Run a build older than the latest release, open Settings, check for updates
2. Click Update and confirm the download and install completes and relaunches

## Screenshots (optional)

N/A

## Linked Issues

N/A

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I tested these changes locally
- [x] Added/updated tests if needed
- [x] Updated README if needed
- [x] `npm run ci` passes (or `npm run lint` and `npm run type-check` at minimum)
- [x] No breaking changes, or I documented them above