### PR TITLE
feat: load tool images into model context

### DIFF
--- a/spec/src-tauri/commands/web_fetch.rs
+++ b/spec/src-tauri/commands/web_fetch.rs
@@ -1,7 +1,9 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use app_lib::commands::http::{is_blocked_ip, is_blocked_proxy_host};
-use app_lib::commands::web_fetch::{accept_header_for_format, WebFetchFormat};
+use app_lib::commands::web_fetch::{
+    accept_header_for_format, is_image_content_type, WebFetchFormat,
+};
 
 #[test]
 fn blocks_metadata_and_link_local() {
@@ -58,4 +60,15 @@ fn accept_header_matches_format() {
     accept_header_for_format(WebFetchFormat::Html),
     "text/html;q=1.0, application/xhtml+xml;q=0.9, text/plain;q=0.8, text/markdown;q=0.7, */*;q=0.1"
   );
+}
+
+#[test]
+fn image_content_type_matches_image_mime() {
+    assert!(is_image_content_type("image/png"));
+    assert!(is_image_content_type("IMAGE/JPEG"));
+    assert!(is_image_content_type("image/webp; charset=binary"));
+    assert!(is_image_content_type("image/svg+xml"));
+    assert!(!is_image_content_type("text/html"));
+    assert!(!is_image_content_type("application/pdf"));
+    assert!(!is_image_content_type("application/octet-stream"));
 }

--- a/spec/src/services/harness/image-stage/registry.test.ts
+++ b/spec/src/services/harness/image-stage/registry.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearStagedImages,
+  drainStagedImages,
+  resetImageStageForTests,
+  stageImage,
+} from '@/services/harness/image-stage'
+
+const normalizeImageDataUrl = vi.hoisted(() =>
+  vi.fn<
+    (args: { dataUrl: string; mediaType: string }) => Promise<{
+      dataUrl: string
+      mediaType: string
+    }>
+  >(async (args) => ({
+    dataUrl: `normalized:${args.dataUrl}`,
+    mediaType: `normalized/${args.mediaType}`,
+  })),
+)
+
+vi.mock('@/utils/normalize-image-data-url', () => ({
+  default: (
+    args: { dataUrl: string; mediaType: string },
+  ): Promise<{ dataUrl: string; mediaType: string }> =>
+    normalizeImageDataUrl(args),
+}))
+
+describe('image-stage registry', () => {
+  beforeEach(() => {
+    resetImageStageForTests()
+    normalizeImageDataUrl.mockClear()
+  })
+
+  it('normalizes each image before storing', async () => {
+    await stageImage({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      image: {
+        dataUrl: 'data:image/png;base64,aaaa',
+        mediaType: 'image/png',
+        source: 'shot.png',
+      },
+    })
+
+    expect(normalizeImageDataUrl).toHaveBeenCalledWith({
+      dataUrl: 'data:image/png;base64,aaaa',
+      mediaType: 'image/png',
+    })
+    expect(drainStagedImages({ chatId: 'chat-1', turnId: 'turn-1' })).toEqual([
+      {
+        dataUrl: 'normalized:data:image/png;base64,aaaa',
+        mediaType: 'normalized/image/png',
+        source: 'shot.png',
+      },
+    ])
+  })
+
+  it('drain returns staged images and empties the turn', async () => {
+    await stageImage({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      image: {
+        dataUrl: 'data:image/png;base64,one',
+        mediaType: 'image/png',
+        source: 'a.png',
+      },
+    })
+    await stageImage({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      image: {
+        dataUrl: 'data:image/png;base64,bbbb',
+        mediaType: 'image/png',
+        source: 'b.png',
+      },
+    })
+
+    const first = drainStagedImages({ chatId: 'chat-1', turnId: 'turn-1' })
+    expect(first).toHaveLength(2)
+    expect(drainStagedImages({ chatId: 'chat-1', turnId: 'turn-1' })).toEqual([])
+  })
+
+  it('clear empties the turn without returning images', async () => {
+    await stageImage({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      image: {
+        dataUrl: 'data:image/png;base64,aaaa',
+        mediaType: 'image/png',
+        source: 'a.png',
+      },
+    })
+
+    clearStagedImages({ chatId: 'chat-1', turnId: 'turn-1' })
+    expect(drainStagedImages({ chatId: 'chat-1', turnId: 'turn-1' })).toEqual([])
+  })
+
+  it('keys isolate chat and turn pairs', async () => {
+    await stageImage({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      image: {
+        dataUrl: 'data:image/png;base64,aaaa',
+        mediaType: 'image/png',
+        source: 'a.png',
+      },
+    })
+    await stageImage({
+      chatId: 'chat-1',
+      turnId: 'turn-2',
+      image: {
+        dataUrl: 'data:image/png;base64,bbbb',
+        mediaType: 'image/png',
+        source: 'b.png',
+      },
+    })
+    await stageImage({
+      chatId: 'chat-2',
+      turnId: 'turn-1',
+      image: {
+        dataUrl: 'data:image/png;base64,cccc',
+        mediaType: 'image/png',
+        source: 'c.png',
+      },
+    })
+
+    expect(drainStagedImages({ chatId: 'chat-1', turnId: 'turn-1' })).toEqual([
+      {
+        dataUrl: 'normalized:data:image/png;base64,aaaa',
+        mediaType: 'normalized/image/png',
+        source: 'a.png',
+      },
+    ])
+    expect(drainStagedImages({ chatId: 'chat-1', turnId: 'turn-2' })).toEqual([
+      {
+        dataUrl: 'normalized:data:image/png;base64,bbbb',
+        mediaType: 'normalized/image/png',
+        source: 'b.png',
+      },
+    ])
+    expect(drainStagedImages({ chatId: 'chat-2', turnId: 'turn-1' })).toEqual([
+      {
+        dataUrl: 'normalized:data:image/png;base64,cccc',
+        mediaType: 'normalized/image/png',
+        source: 'c.png',
+      },
+    ])
+  })
+})

--- a/spec/src/services/harness/orchestrator/consume-stream.test.ts
+++ b/spec/src/services/harness/orchestrator/consume-stream.test.ts
@@ -169,7 +169,7 @@ describe('consumeStream parent prepareStep', () => {
     expect(prepareParentCompactStep).toHaveBeenCalledTimes(1)
     expect(streamText).toHaveBeenCalledWith(
       expect.objectContaining({
-        prepareStep: prepareStep,
+        prepareStep: expect.any(Function),
       }),
     )
     expect(prepareStep).toHaveBeenCalledWith({

--- a/spec/src/services/harness/orchestrator/prepare-image-step.test.ts
+++ b/spec/src/services/harness/orchestrator/prepare-image-step.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ModelMessage } from 'ai'
+import {
+  resetImageStageForTests,
+  stageImage,
+} from '@/services/harness/image-stage'
+import prepareImageStep from '@/services/harness/orchestrator/prepare-image-step'
+
+const normalizeImageDataUrl = vi.hoisted(() =>
+  vi.fn<
+    (args: { dataUrl: string; mediaType: string }) => Promise<{
+      dataUrl: string
+      mediaType: string
+    }>
+  >(async (args) => args),
+)
+
+vi.mock('@/utils/normalize-image-data-url', () => ({
+  default: (
+    args: { dataUrl: string; mediaType: string },
+  ): Promise<{ dataUrl: string; mediaType: string }> =>
+    normalizeImageDataUrl(args),
+}))
+
+const originalMessages: ModelMessage[] = [
+  { role: 'user', content: 'look at this' },
+]
+
+const compactedMessages: ModelMessage[] = [
+  { role: 'user', content: 'compacted' },
+]
+
+describe('prepare-image-step', () => {
+  beforeEach(() => {
+    resetImageStageForTests()
+    normalizeImageDataUrl.mockImplementation(async (args) => args)
+  })
+
+  it('passes through inner undefined when the stage is empty', async () => {
+    const inner = vi.fn<(options: { messages: ModelMessage[] }) => Promise<undefined>>(
+      async () => undefined,
+    )
+    const prepareStep = prepareImageStep({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      inner,
+    })
+
+    await expect(prepareStep({ messages: originalMessages })).resolves.toBeUndefined()
+    expect(inner).toHaveBeenCalledWith({ messages: originalMessages })
+  })
+
+  it('passes through inner messages when the stage is empty', async () => {
+    const inner = vi.fn<
+      (options: { messages: ModelMessage[] }) => Promise<{ messages: ModelMessage[] }>
+    >(async () => ({ messages: compactedMessages }))
+    const prepareStep = prepareImageStep({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      inner,
+    })
+
+    await expect(prepareStep({ messages: originalMessages })).resolves.toEqual({
+      messages: compactedMessages,
+    })
+  })
+
+  it('appends a synthetic user file message when inner returns undefined', async () => {
+    await stageImage({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      image: {
+        dataUrl: 'data:image/png;base64,aaaa',
+        mediaType: 'image/png',
+        source: 'a.png',
+      },
+    })
+    await stageImage({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      image: {
+        dataUrl: 'data:image/jpeg;base64,bbbb',
+        mediaType: 'image/jpeg',
+        source: 'b.jpg',
+      },
+    })
+
+    const inner = vi.fn<(options: { messages: ModelMessage[] }) => Promise<undefined>>(
+      async () => undefined,
+    )
+    const prepareStep = prepareImageStep({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      inner,
+    })
+
+    const result = await prepareStep({ messages: originalMessages })
+    expect(result).toEqual({
+      messages: [
+        ...originalMessages,
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Images loaded by tools (sources: a.png, b.jpg):',
+            },
+            {
+              type: 'file',
+              data: 'data:image/png;base64,aaaa',
+              mediaType: 'image/png',
+            },
+            {
+              type: 'file',
+              data: 'data:image/jpeg;base64,bbbb',
+              mediaType: 'image/jpeg',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('appends a synthetic user file message onto compacted messages', async () => {
+    await stageImage({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      image: {
+        dataUrl: 'data:image/png;base64,aaaa',
+        mediaType: 'image/png',
+        source: 'shot.png',
+      },
+    })
+
+    const inner = vi.fn<
+      (options: { messages: ModelMessage[] }) => Promise<{ messages: ModelMessage[] }>
+    >(async () => ({ messages: compactedMessages }))
+    const prepareStep = prepareImageStep({
+      chatId: 'chat-1',
+      turnId: 'turn-1',
+      inner,
+    })
+
+    const result = await prepareStep({ messages: originalMessages })
+    expect(result).toEqual({
+      messages: [
+        ...compactedMessages,
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Images loaded by tools (sources: shot.png):',
+            },
+            {
+              type: 'file',
+              data: 'data:image/png;base64,aaaa',
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/spec/src/services/harness/read/file.test.ts
+++ b/spec/src/services/harness/read/file.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { VixlSettings } from '@/types/vixl/vixl-settings'
+import type { HarnessToolContext } from '@/types/harness/tool-context'
+import { mockVixlTauri } from '../../../test-utils/mocks/vixl-tauri'
+
+const fsReadFile = vi.hoisted(() =>
+  vi.fn<
+    (args: {
+      projectRoot: string
+      path: string
+      offset?: number
+      limit?: number
+      includeBase64?: boolean
+    }) => Promise<{
+      path: string
+      content: string
+      totalLines: number
+      offset: number
+      limit: number
+      isImage?: boolean
+      mimeType?: string
+      sizeBytes?: number
+      base64?: string
+    }>
+  >(),
+)
+
+vi.mock('@/services/vixl/vixl-tauri', () =>
+  mockVixlTauri({
+    fsReadFile: (
+      args: {
+        projectRoot: string
+        path: string
+        offset?: number
+        limit?: number
+        includeBase64?: boolean
+      },
+    ) => fsReadFile(args),
+  }),
+)
+
+import readFile from '@/services/harness/read/file'
+
+const baseCtx = (overrides?: Partial<HarnessToolContext>): HarnessToolContext => ({
+  projectRoot: '/tmp/project',
+  projectSlug: 'project',
+  chatId: 'chat-1',
+  mode: 'agent',
+  settings: { version: 1 } as VixlSettings,
+  permissionLevel: 'ask',
+  sessionAllows: new Set(),
+  sessionDenies: new Set(),
+  sandboxEnabled: true,
+  supportsVision: false,
+  onPendingApproval: () => {},
+  ...overrides,
+})
+
+const execute = async (
+  input: Record<string, unknown>,
+  ctx: HarnessToolContext = baseCtx(),
+): Promise<unknown> => {
+  const built = readFile(ctx)
+  const runner = built.execute as (
+    value: Record<string, unknown>,
+    options: { toolCallId: string },
+  ) => Promise<unknown>
+  return runner(input, { toolCallId: 'call-1' })
+}
+
+describe('read_file tool images', () => {
+  beforeEach(() => {
+    fsReadFile.mockReset()
+  })
+
+  it('stages vision images and omits base64', async () => {
+    const stageImage = vi.fn<
+      (image: { dataUrl: string; mediaType: string; source: string }) => Promise<void>
+    >(async () => undefined)
+    fsReadFile.mockResolvedValueOnce({
+      path: 'shot.png',
+      content: '',
+      totalLines: 0,
+      offset: 1,
+      limit: 0,
+      isImage: true,
+      mimeType: 'image/png',
+      sizeBytes: 12,
+    })
+    fsReadFile.mockResolvedValueOnce({
+      path: 'shot.png',
+      content: '',
+      totalLines: 0,
+      offset: 1,
+      limit: 0,
+      isImage: true,
+      mimeType: 'image/png',
+      sizeBytes: 12,
+      base64: 'aaaa',
+    })
+
+    const result = await execute(
+      { path: 'shot.png' },
+      baseCtx({ supportsVision: true, stageImage }),
+    )
+
+    expect(fsReadFile).toHaveBeenNthCalledWith(1, {
+      projectRoot: '/tmp/project',
+      path: 'shot.png',
+      offset: undefined,
+      limit: undefined,
+      includeBase64: undefined,
+    })
+    expect(fsReadFile).toHaveBeenNthCalledWith(2, {
+      projectRoot: '/tmp/project',
+      path: 'shot.png',
+      includeBase64: true,
+    })
+    expect(stageImage).toHaveBeenCalledWith({
+      dataUrl: 'data:image/png;base64,aaaa',
+      mediaType: 'image/png',
+      source: 'shot.png',
+    })
+    expect(result).toEqual({
+      path: 'shot.png',
+      isImage: true,
+      loadedIntoContext: true,
+      mimeType: 'image/png',
+      sizeBytes: 12,
+    })
+    expect(result).not.toHaveProperty('base64')
+  })
+
+  it('keeps metadata and base64 when stageImage is absent', async () => {
+    fsReadFile.mockResolvedValue({
+      path: 'shot.png',
+      content: '',
+      totalLines: 0,
+      offset: 1,
+      limit: 0,
+      isImage: true,
+      mimeType: 'image/png',
+      sizeBytes: 12,
+      base64: 'aaaa',
+    })
+
+    const result = await execute(
+      { path: 'shot.png', include_base64: true },
+      baseCtx({ supportsVision: false }),
+    )
+
+    expect(fsReadFile).toHaveBeenCalledTimes(1)
+    expect(fsReadFile).toHaveBeenCalledWith({
+      projectRoot: '/tmp/project',
+      path: 'shot.png',
+      offset: undefined,
+      limit: undefined,
+      includeBase64: true,
+    })
+    expect(result).toEqual({
+      path: 'shot.png',
+      isImage: true,
+      mimeType: 'image/png',
+      sizeBytes: 12,
+      content: null,
+      base64: 'aaaa',
+    })
+  })
+
+  it('returns text file results unchanged', async () => {
+    const textResult = {
+      path: 'src/a.ts',
+      content: 'export const a = 1',
+      totalLines: 1,
+      offset: 1,
+      limit: 200,
+    }
+    fsReadFile.mockResolvedValue(textResult)
+
+    await expect(execute({ path: 'src/a.ts', offset: 1, limit: 20 })).resolves.toEqual(
+      textResult,
+    )
+  })
+})

--- a/spec/src/services/harness/subagent/run-generate.test.ts
+++ b/spec/src/services/harness/subagent/run-generate.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { VixlSettings } from '@/types/vixl/vixl-settings'
 import type { HarnessToolContext } from '@/types/harness/tool-context'
+import type { StagedImage } from '@/types/harness/staged-image'
 import estimateTextTokens from '@/utils/estimate-text-tokens'
 
 const generateText = vi.hoisted(() =>
@@ -231,6 +232,25 @@ describe('runSubagentGenerate pending approval tagging', () => {
     const nestedCtx = buildHarnessTools.mock.calls[0]?.[0] as HarnessToolContext
     expect(nestedCtx.sessionAllows).toBe(ctx.sessionAllows)
     expect(nestedCtx.sessionDenies).toBe(ctx.sessionDenies)
+  })
+
+  it('does not inherit parent stageImage on nested tool context', async () => {
+    const stageImage = vi.fn<(image: StagedImage) => Promise<void>>()
+    const ctx = { ...baseCtx(), stageImage }
+    await runSubagentGenerate({
+      ctx,
+      subagentId: 'sub-1',
+      agentName: 'explore',
+      prompt: 'describe the screenshot',
+      toolCallId: 'call-1',
+      signal: new AbortController().signal,
+      model: 'local::qwen',
+      capabilities: 'read-only',
+    })
+
+    const nestedCtx = buildHarnessTools.mock.calls[0]?.[0] as HarnessToolContext
+    expect(nestedCtx.stageImage).toBeUndefined()
+    expect(stageImage).not.toHaveBeenCalled()
   })
 })
 

--- a/spec/src/services/harness/web/fetch.test.ts
+++ b/spec/src/services/harness/web/fetch.test.ts
@@ -1,13 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { VixlSettings } from '@/types/vixl/vixl-settings'
 import type { HarnessToolContext } from '@/types/harness/tool-context'
+import type { StagedImage } from '@/types/harness/staged-image'
+import type {
+  WebFetchRequest,
+  WebFetchResponse,
+} from '@/services/vixl/vixl-tauri/types'
 
 const gateToolPermission = vi.hoisted(() =>
   vi.fn<() => Promise<boolean>>().mockResolvedValue(true),
 )
 
 const webFetch = vi.hoisted(() =>
-  vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+  vi.fn<(request: WebFetchRequest) => Promise<WebFetchResponse>>(),
 )
 
 const convertWebContent = vi.hoisted(() =>
@@ -174,5 +179,85 @@ describe('web_fetch tool', () => {
     const result = await execute({ url: 'not a url' })
     expect(result).toEqual({ error: 'Invalid URL' })
     expect(webFetch).not.toHaveBeenCalled()
+  })
+
+  it('stages vision images and returns loadedIntoContext', async () => {
+    const stageImage = vi.fn<(image: StagedImage) => Promise<void>>(
+      async () => undefined,
+    )
+    webFetch.mockResolvedValue({
+      status: 200,
+      body: '',
+      headers: { 'Content-Type': 'image/png' },
+      isImage: true,
+      bodyBase64: 'aaaa',
+    })
+
+    const result = await execute(
+      { url: 'https://github.com/user-attachments/assets/shot.png' },
+      { ...baseCtx(), supportsVision: true, stageImage },
+    )
+
+    expect(gateToolPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capability: 'web.fetch:github.com',
+        action: 'web.fetch',
+      }),
+    )
+    expect(webFetch).toHaveBeenCalledTimes(1)
+    expect(convertWebContent).not.toHaveBeenCalled()
+    expect(stageImage).toHaveBeenCalledWith({
+      dataUrl: 'data:image/png;base64,aaaa',
+      mediaType: 'image/png',
+      source: 'https://github.com/user-attachments/assets/shot.png',
+    })
+    expect(result).toEqual({
+      status: 200,
+      contentType: 'image/png',
+      isImage: true,
+      loadedIntoContext: true,
+    })
+  })
+
+  it('returns a cannot-view-images error when stageImage is absent', async () => {
+    webFetch.mockResolvedValue({
+      status: 200,
+      body: '',
+      headers: { 'Content-Type': 'image/png' },
+      isImage: true,
+      bodyBase64: 'aaaa',
+    })
+
+    const result = await execute({
+      url: 'https://example.com/shot.png',
+    })
+
+    expect(webFetch).toHaveBeenCalledTimes(1)
+    expect(convertWebContent).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      error: 'This URL is an image and this model cannot view images.',
+      status: 200,
+      contentType: 'image/png',
+    })
+  })
+
+  it('leaves non-image responses unchanged', async () => {
+    const stageImage = vi.fn<(image: StagedImage) => Promise<void>>(
+      async () => undefined,
+    )
+
+    const result = (await execute(
+      { url: 'https://example.com/docs' },
+      { ...baseCtx(), supportsVision: true, stageImage },
+    )) as Record<string, unknown>
+
+    expect(stageImage).not.toHaveBeenCalled()
+    expect(convertWebContent).toHaveBeenCalled()
+    expect(result.status).toBe(200)
+    expect(result.isImage).toBeUndefined()
+    expect(result.loadedIntoContext).toBeUndefined()
+    expect(String(result.text)).toContain(
+      'Untrusted web content from https://example.com/docs',
+    )
   })
 })

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5362,7 +5362,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vixl"
-version = "0.1.0-beta.5"
+version = "0.0.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/commands/web_fetch.rs
+++ b/src-tauri/src/commands/web_fetch.rs
@@ -41,6 +41,8 @@ pub struct WebFetchResponse {
     pub body: String,
     pub headers: HashMap<String, String>,
     pub truncated: bool,
+    pub is_image: bool,
+    pub body_base64: Option<String>,
 }
 
 pub fn accept_header_for_format(format: WebFetchFormat) -> &'static str {
@@ -57,14 +59,22 @@ pub fn accept_header_for_format(format: WebFetchFormat) -> &'static str {
   }
 }
 
-fn is_binary_content_type(content_type: &str) -> bool {
-    let mime = content_type
+fn mime_essence(content_type: &str) -> String {
+    content_type
         .split(';')
         .next()
         .unwrap_or(content_type)
         .trim()
-        .to_ascii_lowercase();
+        .to_ascii_lowercase()
+}
+
+fn is_binary_content_type(content_type: &str) -> bool {
+    let mime = mime_essence(content_type);
     mime == "application/pdf" || mime == "application/octet-stream"
+}
+
+pub fn is_image_content_type(content_type: &str) -> bool {
+    mime_essence(content_type).starts_with("image/")
 }
 
 fn build_request_headers(format: WebFetchFormat) -> HeaderMap {
@@ -141,6 +151,24 @@ pub async fn web_fetch(request: WebFetchRequest) -> Result<WebFetchResponse, Str
     }
 
     let bytes = read_body_capped(response).await?;
+
+    if let Some(content_type) = response_headers.get("content-type") {
+        if is_image_content_type(content_type) {
+            let encoded = base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                &bytes,
+            );
+            return Ok(WebFetchResponse {
+                status,
+                body: String::new(),
+                headers: response_headers,
+                truncated: false,
+                is_image: true,
+                body_base64: Some(encoded),
+            });
+        }
+    }
+
     let body = String::from_utf8(bytes).map_err(|_| {
         "Response content is binary (not valid UTF-8) and cannot be fetched as text".to_string()
     })?;
@@ -150,5 +178,7 @@ pub async fn web_fetch(request: WebFetchRequest) -> Result<WebFetchResponse, Str
         body,
         headers: response_headers,
         truncated: false,
+        is_image: false,
+        body_base64: None,
     })
 }

--- a/src/services/harness/image-stage/clear.ts
+++ b/src/services/harness/image-stage/clear.ts
@@ -1,0 +1,5 @@
+import imageStageStore from './store'
+
+export default (args: { chatId: string; turnId: string }): void => {
+  imageStageStore.delete(args.chatId, args.turnId)
+}

--- a/src/services/harness/image-stage/drain.ts
+++ b/src/services/harness/image-stage/drain.ts
@@ -1,0 +1,8 @@
+import type { StagedImage } from '@/types/harness/staged-image'
+import imageStageStore from './store'
+
+export default (args: { chatId: string; turnId: string }): StagedImage[] => {
+  const images = imageStageStore.get(args.chatId, args.turnId)
+  imageStageStore.delete(args.chatId, args.turnId)
+  return images
+}

--- a/src/services/harness/image-stage/index.ts
+++ b/src/services/harness/image-stage/index.ts
@@ -1,0 +1,4 @@
+export { default as stageImage } from './stage'
+export { default as drainStagedImages } from './drain'
+export { default as clearStagedImages } from './clear'
+export { default as resetImageStageForTests } from './reset'

--- a/src/services/harness/image-stage/reset.ts
+++ b/src/services/harness/image-stage/reset.ts
@@ -1,0 +1,5 @@
+import imageStageStore from './store'
+
+export default (): void => {
+  imageStageStore.reset()
+}

--- a/src/services/harness/image-stage/stage.ts
+++ b/src/services/harness/image-stage/stage.ts
@@ -1,0 +1,23 @@
+import type { StagedImage } from '@/types/harness/staged-image'
+import normalizeImageDataUrl from '@/utils/normalize-image-data-url'
+import imageStageStore from './store'
+
+export default async (args: {
+  chatId: string
+  turnId: string
+  image: StagedImage
+}): Promise<void> => {
+  const normalized = await normalizeImageDataUrl({
+    dataUrl: args.image.dataUrl,
+    mediaType: args.image.mediaType,
+  })
+  const existing = imageStageStore.get(args.chatId, args.turnId)
+  imageStageStore.set(args.chatId, args.turnId, [
+    ...existing,
+    {
+      dataUrl: normalized.dataUrl,
+      mediaType: normalized.mediaType,
+      source: args.image.source,
+    },
+  ])
+}

--- a/src/services/harness/image-stage/store.ts
+++ b/src/services/harness/image-stage/store.ts
@@ -1,0 +1,21 @@
+import type { StagedImage } from '@/types/harness/staged-image'
+
+const byTurn = new Map<string, StagedImage[]>()
+
+const turnKey = (chatId: string, turnId: string): string => `${chatId}\0${turnId}`
+
+const imageStageStore = {
+  get: (chatId: string, turnId: string): StagedImage[] =>
+    byTurn.get(turnKey(chatId, turnId)) ?? [],
+  set: (chatId: string, turnId: string, images: StagedImage[]): void => {
+    byTurn.set(turnKey(chatId, turnId), images)
+  },
+  delete: (chatId: string, turnId: string): void => {
+    byTurn.delete(turnKey(chatId, turnId))
+  },
+  reset: (): void => {
+    byTurn.clear()
+  },
+}
+
+export default imageStageStore

--- a/src/services/harness/orchestrator/consume-stream.ts
+++ b/src/services/harness/orchestrator/consume-stream.ts
@@ -5,6 +5,7 @@ import { rejectPendingForChat } from '@/services/harness/permission/approval-gat
 import { rejectPendingQuestionsForChat } from '@/services/harness/permission/question-gate'
 import { rejectPendingMcpAuthForChat } from '@/services/mcp/mcp-auth-gate'
 import enrichToolError from '@/services/harness/enrich-tool-error'
+import { clearStagedImages } from '@/services/harness/image-stage'
 import { killShellsForChat } from '@/services/harness/shell/registry'
 import { abort as abortSubagentsForChat } from '@/services/harness/subagent/registry'
 import {
@@ -22,6 +23,7 @@ import {
 } from './helpers'
 import { persistLine } from './persistence'
 import prepareParentCompactStep from './prepare-compact-step'
+import prepareImageStep from './prepare-image-step'
 import type { PreparedHarnessStream } from './prepare-stream'
 
 export default async (prepared: PreparedHarnessStream): Promise<void> => {
@@ -87,25 +89,30 @@ export default async (prepared: PreparedHarnessStream): Promise<void> => {
       isLoopFinished(),
       () => getPlanExecutionSession(workspace.projectSlug, chatId).createdPlanThisTurn,
     ],
-    prepareStep: prepareParentCompactStep({
-      settings,
-      model,
-      modelRef: callModel.optionRef,
-      system,
-      providerOptions: callOptions.providerOptions,
-      tools,
-      signal,
-      workspace,
+    prepareStep: prepareImageStep({
       chatId,
       turnId: assistantId,
-      messages,
-      onEvent,
+      inner: prepareParentCompactStep({
+        settings,
+        model,
+        modelRef: callModel.optionRef,
+        system,
+        providerOptions: callOptions.providerOptions,
+        tools,
+        signal,
+        workspace,
+        chatId,
+        turnId: assistantId,
+        messages,
+        onEvent,
+      }),
     }),
     abortSignal: signal,
     onAbort: async () => {
       rejectPendingForChat(chatId)
       rejectPendingQuestionsForChat(chatId)
       rejectPendingMcpAuthForChat(chatId)
+      clearStagedImages({ chatId, turnId: assistantId })
       await killShellsForChat(chatId)
       abortSubagentsForChat(chatId)
       if (steps.trailingText || steps.assistantReasoning) {
@@ -287,21 +294,25 @@ export default async (prepared: PreparedHarnessStream): Promise<void> => {
     setTurnResponseMessages(chatId, responseMessages)
   }
 
-  if (streamError && !signal.aborted) {
-    throw streamError
-  }
+  try {
+    if (streamError && !signal.aborted) {
+      throw streamError
+    }
 
-  if (!signal.aborted && (steps.trailingText || steps.assistantReasoning)) {
-    await persistLine(workspace.projectSlug, chatId, {
-      id: assistantId,
-      role: 'assistant',
-      parts: [
-        ...(steps.assistantReasoning
-          ? [{ type: 'reasoning', text: steps.assistantReasoning }]
-          : []),
-        ...(steps.trailingText ? [{ type: 'text', text: steps.trailingText }] : []),
-      ],
-      createdAt: nowIso(),
-    })
+    if (!signal.aborted && (steps.trailingText || steps.assistantReasoning)) {
+      await persistLine(workspace.projectSlug, chatId, {
+        id: assistantId,
+        role: 'assistant',
+        parts: [
+          ...(steps.assistantReasoning
+            ? [{ type: 'reasoning', text: steps.assistantReasoning }]
+            : []),
+          ...(steps.trailingText ? [{ type: 'text', text: steps.trailingText }] : []),
+        ],
+        createdAt: nowIso(),
+      })
+    }
+  } finally {
+    clearStagedImages({ chatId, turnId: assistantId })
   }
 }

--- a/src/services/harness/orchestrator/prepare-image-step.ts
+++ b/src/services/harness/orchestrator/prepare-image-step.ts
@@ -1,0 +1,50 @@
+import type { ModelMessage } from 'ai'
+import { drainStagedImages } from '@/services/harness/image-stage'
+
+type PrepareStepOptions = {
+  messages: ModelMessage[]
+}
+
+type PrepareStepResult = {
+  messages?: ModelMessage[]
+}
+
+type PrepareStepFn = (
+  options: PrepareStepOptions,
+) => Promise<PrepareStepResult | undefined>
+
+export default (args: {
+  chatId: string
+  turnId: string
+  inner: PrepareStepFn
+}) =>
+  async (options: PrepareStepOptions): Promise<PrepareStepResult | undefined> => {
+    const innerResult = await args.inner(options)
+    const staged = drainStagedImages({
+      chatId: args.chatId,
+      turnId: args.turnId,
+    })
+
+    if (staged.length === 0) {
+      return innerResult
+    }
+
+    const sources = staged.map((image) => image.source).join(', ')
+    const imageMessage: ModelMessage = {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: `Images loaded by tools (sources: ${sources}):`,
+        },
+        ...staged.map((image) => ({
+          type: 'file' as const,
+          data: image.dataUrl,
+          mediaType: image.mediaType,
+        })),
+      ],
+    }
+
+    const baseMessages = innerResult?.messages ?? options.messages
+    return { messages: [...baseMessages, imageMessage] }
+  }

--- a/src/services/harness/orchestrator/prepare-stream.ts
+++ b/src/services/harness/orchestrator/prepare-stream.ts
@@ -34,6 +34,8 @@ import resolveModelRefForCall from '@/services/models/resolve-model-ref-for-call
 import { toast } from 'vue-sonner'
 import formatUnknownError from '@/utils/format-unknown-error'
 import resolveModelVision from '@/services/harness/resolve-model-vision'
+import { stageImage } from '@/services/harness/image-stage'
+import type { StagedImage } from '@/types/harness/staged-image'
 import {
   filterToolsForMode,
   injectContextIntoLastUserMessage,
@@ -248,6 +250,16 @@ export default async (input: HarnessStreamInput): Promise<PreparedHarnessStream>
       sessionDenies,
       sandboxEnabled: settings['agent.sandbox.enabled'] ?? true,
       supportsVision,
+      ...(supportsVision
+        ? {
+            stageImage: (image: StagedImage) =>
+              stageImage({
+                chatId,
+                turnId: assistantId,
+                image,
+              }),
+          }
+        : {}),
       onPendingApproval: (entry) => {
         onEvent({
           type: 'tool-pending-approval',

--- a/src/services/harness/read/file.ts
+++ b/src/services/harness/read/file.ts
@@ -3,10 +3,25 @@ import { z } from 'zod'
 import { fsReadFile } from '@/services/vixl/vixl-tauri'
 import type { HarnessToolContext } from '@/types/harness/tool-context'
 
+const imageReadResult = (args: {
+  path: string
+  mimeType: string | null
+  sizeBytes: number | null
+  content: string | null
+  base64: string | null
+}) => ({
+  path: args.path,
+  isImage: true as const,
+  mimeType: args.mimeType,
+  sizeBytes: args.sizeBytes,
+  content: args.content,
+  base64: args.base64,
+})
+
 const readFile = (ctx: HarnessToolContext) =>
   tool({
     description:
-      'Read a file from the workspace (images return metadata, optionally base64).',
+      'Read a file from the workspace. For vision models, images are loaded into context automatically. Otherwise images return metadata, optionally with base64.',
     inputSchema: z.object({
       path: z.string().describe('Workspace-relative file path'),
       offset: z.number().optional().describe('1-based start line'),
@@ -22,18 +37,60 @@ const readFile = (ctx: HarnessToolContext) =>
         includeBase64: include_base64,
       })
 
-      if (result.isImage) {
-        return {
+      if (!result.isImage) {
+        return result
+      }
+
+      if (!ctx.stageImage) {
+        return imageReadResult({
           path: result.path,
-          isImage: true,
           mimeType: result.mimeType ?? null,
           sizeBytes: result.sizeBytes ?? null,
           content: result.content || null,
           base64: result.base64 ?? null,
-        }
+        })
       }
 
-      return result
+      let base64 = result.base64
+      let mimeType = result.mimeType
+      let sizeBytes = result.sizeBytes
+      let resolvedPath = result.path
+
+      if (!base64) {
+        const withBase64 = await fsReadFile({
+          projectRoot: ctx.projectRoot,
+          path,
+          includeBase64: true,
+        })
+        base64 = withBase64.base64
+        mimeType = withBase64.mimeType ?? mimeType
+        sizeBytes = withBase64.sizeBytes ?? sizeBytes
+        resolvedPath = withBase64.path
+      }
+
+      if (!base64 || !mimeType) {
+        return imageReadResult({
+          path: resolvedPath,
+          mimeType: mimeType ?? null,
+          sizeBytes: sizeBytes ?? null,
+          content: result.content || null,
+          base64: base64 ?? null,
+        })
+      }
+
+      await ctx.stageImage({
+        dataUrl: `data:${mimeType};base64,${base64}`,
+        mediaType: mimeType,
+        source: resolvedPath,
+      })
+
+      return {
+        path: resolvedPath,
+        isImage: true as const,
+        loadedIntoContext: true as const,
+        mimeType,
+        sizeBytes: sizeBytes ?? null,
+      }
     },
   })
 

--- a/src/services/harness/subagent/run-generate.ts
+++ b/src/services/harness/subagent/run-generate.ts
@@ -108,6 +108,8 @@ const runSubagentGenerate = async (args: {
   const nestedCtx: HarnessToolContext = {
     ...ctx,
     supportsVision,
+    // Subagents opt out of image staging: generateText has no stage drain.
+    stageImage: undefined,
     onHarnessEvent: emitNestedEvent,
     onPendingApproval: (entry) => {
       ctx.onPendingApproval({ ...entry, subagentId, subagentLabel: safeName })

--- a/src/services/harness/web/fetch.ts
+++ b/src/services/harness/web/fetch.ts
@@ -29,10 +29,15 @@ const headerValue = (
   return undefined
 }
 
+const imageMediaType = (contentType: string): string => {
+  const mime = contentType.split(';')[0]?.trim()
+  return mime || contentType
+}
+
 const webFetchTool = (ctx: HarnessToolContext) =>
   tool({
     description:
-      'Fetch an http(s) URL as markdown (default), text, or html. No JavaScript.',
+      'Fetch an http(s) URL as markdown (default), text, or html. No JavaScript. Image URLs are loaded into context automatically for vision models.',
     inputSchema: z.object({
       url: z.string().describe('http or https URL to fetch'),
       max_length: z
@@ -105,6 +110,51 @@ const webFetchTool = (ctx: HarnessToolContext) =>
 
         const contentType =
           headerValue(response.headers, 'content-type') ?? ''
+
+        if (response.isImage) {
+          if (!ctx.stageImage) {
+            return {
+              error:
+                'This URL is an image and this model cannot view images.',
+              status: response.status,
+              contentType,
+            }
+          }
+
+          if (!response.bodyBase64) {
+            return {
+              error: 'Image response was missing body data.',
+              status: response.status,
+              contentType,
+            }
+          }
+
+          const mediaType = imageMediaType(contentType)
+          try {
+            await ctx.stageImage({
+              dataUrl: `data:${mediaType};base64,${response.bodyBase64}`,
+              mediaType,
+              source: parsed.href,
+            })
+          } catch (error) {
+            return {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to load image into context',
+              status: response.status,
+              contentType,
+            }
+          }
+
+          return {
+            status: response.status,
+            contentType,
+            isImage: true as const,
+            loadedIntoContext: true as const,
+          }
+        }
+
         const converted = convertWebContent({
           body: response.body,
           contentType,

--- a/src/services/vixl/vixl-tauri/types.ts
+++ b/src/services/vixl/vixl-tauri/types.ts
@@ -64,6 +64,8 @@ export type WebFetchResponse = {
   status: number
   body: string
   headers: Record<string, string>
+  isImage?: boolean
+  bodyBase64?: string
 }
 
 export type ChatMetaRecord = {

--- a/src/types/harness/index.ts
+++ b/src/types/harness/index.ts
@@ -1,4 +1,5 @@
 export type { HarnessToolContext } from '@/types/harness/tool-context'
+export type { StagedImage } from '@/types/harness/staged-image'
 export type { HarnessWorkspace } from '@/types/harness/harness-workspace'
 export type { HarnessStreamInput } from '@/types/harness/harness-stream-input'
 export type {

--- a/src/types/harness/staged-image.ts
+++ b/src/types/harness/staged-image.ts
@@ -1,0 +1,5 @@
+export type StagedImage = {
+  dataUrl: string
+  mediaType: string
+  source: string
+}

--- a/src/types/harness/tool-context.ts
+++ b/src/types/harness/tool-context.ts
@@ -1,6 +1,7 @@
 import type { PendingApprovalView } from '@/services/harness/permission/gate'
 import type { HarnessEvent } from '@/types/harness/harness-event'
 import type { PermissionCapabilityKey, PermissionLevel } from '@/types/harness/permission'
+import type { StagedImage } from '@/types/harness/staged-image'
 import type { VixlChatMode, VixlSettings } from '@/types/vixl/vixl-settings'
 
 type HarnessToolContext = {
@@ -18,6 +19,8 @@ type HarnessToolContext = {
   sessionDenies: Set<string>
   sandboxEnabled: boolean
   supportsVision: boolean
+  /** Present when the parent model can take user-message images. Subagents may omit this. */
+  stageImage?: (image: StagedImage) => Promise<void>
   onPendingApproval: (entry: PendingApprovalView) => void
   persistPermission?: (
     capability: PermissionCapabilityKey,


### PR DESCRIPTION
Tools (read, web_fetch) stage images per turn; prepareStep drains the stage into a synthetic user message with file parts so vision models see tool-loaded images on every provider, including z.ai via AI Gateway. web_fetch returns base64 for image/* responses. Subagents opt out of staging. Synthetic messages are ephemeral and not persisted to JSONL.